### PR TITLE
Wave 1検証ToEと計画ドキュメントを日本語化する

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,41 +1,43 @@
 # Repository Guidelines
 
-## Project Structure & Module Organization
+## プロジェクト構成
 
-This is a small Node.js ESM application centered on `index.js`. It starts a Fastify server, handles Twilio Voice webhooks, bridges Twilio Media Streams to the OpenAI Realtime API, and processes transcripts after disconnect.
+このリポジトリは、Twilio Voice / Media Streams と OpenAI Realtime API をつなぐ日本向け音声AI受付システムです。現時点の本体は `index.js` です。
 
-- `index.js`: main server, WebSocket bridge, session tracking, transcript extraction.
-- `Readme.md`: setup and local testing instructions, currently written in Japanese.
-- `.env.example`: required environment variable template.
-- `package.json` / `package-lock.json`: npm metadata and locked dependency versions.
-- No dedicated `src/`, `test/`, or asset directories exist yet.
+- `index.js`: Fastifyサーバー、Twilio webhook、Media Streams WebSocket、OpenAI Realtime接続
+- `scripts/`: ローカル検証用スクリプト
+- `docs/`: ADR、実装計画、検証手順
+- `.env.example`: 環境変数のテンプレート
+- `.github/workflows/ci.yml`: 最小CI
 
-## Build, Test, and Development Commands
+## 開発コマンド
 
-- `npm install`: install dependencies from `package-lock.json`.
-- `cp .env.example .env`: create local configuration, then set `OPENAI_API_KEY`.
-- `npm run start`: run the Fastify server on `PORT` or `5050`.
-- `npm run check`: run a Node syntax check for `index.js`.
-- `npm run smoke:local`: verify `/`, `/healthz`, and `/incoming-call` against a running local server.
-- `ngrok http 5050`: expose the local server for Twilio webhook testing.
-- `npm test`: currently runs the syntax check.
+- `npm ci`: lockfileに基づいて依存関係をインストールします。
+- `npm run start`: ローカルサーバーを起動します。
+- `npm run check`: `index.js` の構文チェックを実行します。
+- `npm test`: 現時点では `npm run check` を実行します。
+- `npm run check:realtime`: OpenAI Realtimeへ接続し、GA形式の `session.update` を検証します。
+- `npm run smoke:local`: `/`, `/healthz`, `/incoming-call` を検証します。
+- `npm run smoke:media-stream`: Twilio Media Streams互換のWebSocket検証を行います。
 
-## Coding Style & Naming Conventions
+## コーディング規約
 
-Use modern JavaScript ESM syntax because `package.json` sets `"type": "module"`. Keep indentation at 4 spaces to match `index.js`. Prefer `const` for stable bindings and `let` only for reassigned state. Use camelCase for variables and functions, and uppercase names for constants such as `SYSTEM_MESSAGE`, `VOICE`, and `PORT`.
+JavaScriptはESMで書きます。インデントは既存コードに合わせて4スペースを使います。設定値、モデル名、VAD値、音声設定はコード直書きではなく環境変数へ寄せてください。
 
-No formatter or linter is configured. Before adding broad style changes, introduce tooling deliberately in a separate change.
+## テスト方針
 
-## Testing Guidelines
+最低限、変更前後で `npm test` を通してください。RealtimeやTwilio経路を触る場合は、`check:realtime`、`smoke:local`、`smoke:media-stream` の結果もPR本文へ記録します。
 
-There is no test framework configured. For new behavior, add focused tests under `test/` with Node's built-in test runner or another explicitly configured framework. Name tests by behavior, for example `test/media-stream-session.test.js`. At minimum, manually verify startup with `node index.js`, the root health response, and a Twilio call through ngrok when touching WebSocket or TwiML behavior.
+## ブランチ運用
 
-## Commit & Pull Request Guidelines
+- `main`: 本番安定版
+- `develop`: 開発統合先
+- `feature/*`: 新機能
+- `fix/*`: 修正
+- `docs/*`: ドキュメント変更
 
-The existing history uses short informal messages (`first commit`, `for trial`), so there is no strict convention. Use concise imperative commit messages going forward, for example `Add transcript extraction validation`.
+`main` と `develop` は保護されています。PR経由で変更してください。
 
-Pull requests should describe behavior changes, list manual test steps, mention required environment variables, and include logs or screenshots when changing call setup, ngrok/Twilio configuration, or API responses.
+## セキュリティ
 
-## Security & Configuration Tips
-
-Never commit `.env` or real API keys. Keep `.env.example` limited to placeholder values. Avoid logging sensitive customer details beyond what is necessary for local debugging, especially transcripts, names, phone numbers, and visit dates.
+`.env`、APIキー、Twilio Auth Token、通話録音、全文トランスクリプト、電話番号をコミットしないでください。本番ログでは個人情報を最小化し、必要な場合だけ明示的に有効化します。

--- a/docs/adr/0001-2026-modernization-plan.md
+++ b/docs/adr/0001-2026-modernization-plan.md
@@ -1,5 +1,5 @@
-# ADR 0001: 2026 Modernization Plan
+# ADR 0001: 2026年版モダナイゼーション計画
 
-This ADR has moved to [0001-2026-production-modernization.md](./0001-2026-production-modernization.md).
+このADRは [0001-2026-production-modernization.md](./0001-2026-production-modernization.md) に移動しました。
 
-The original plan was expanded to include React operator monitoring, Twilio Voice SDK browser WebRTC, and Conference-based human handoff.
+当初の計画は、Reactによるオペレーター監視、Twilio Voice SDKによるブラウザWebRTC、Twilio Conferenceを使った人間への引き継ぎまで含む形に拡張されています。

--- a/docs/adr/0001-2026-production-modernization.md
+++ b/docs/adr/0001-2026-production-modernization.md
@@ -1,86 +1,83 @@
-# ADR 0001: 2026 Production Modernization
+# ADR 0001: 2026年版プロダクション移行
 
-- Status: Proposed
-- Date: 2026-04-26
-- Supersedes: initial prototype-only deployment assumptions
-- Scope: OpenAI Realtime, Twilio telephony, React admin UI, human handoff, Cloud Run deployment, Japanese `050` launch
+- ステータス: 提案中
+- 日付: 2026-04-26
+- 対象: OpenAI Realtime、Twilio電話連携、React管理画面、人間への引き継ぎ、Cloud Run、050番号
 
-## Context
+## 背景
 
-The current repository is a single-file Node.js prototype. It accepts Twilio Voice calls, opens a bidirectional Media Stream WebSocket, forwards audio to the OpenAI Realtime API, and logs a post-call transcript extraction. That design proved the concept, but it does not yet support production operation.
+現行リポジトリは、単一の `index.js` でTwilio Voice着信を受け、Media StreamsをOpenAI Realtime APIへ中継するプロトタイプです。概念実証としては成立していますが、日本のコールセンターで運用するには、デプロイ、監視、設定管理、通話引き継ぎ、個人情報保護が不足しています。
 
-The product now needs five capabilities:
+解決すべき主要課題は次の通りです。
 
-1. Move from a Replit/ngrok-style workflow to a reproducible cloud deployment.
-2. Add an operator UI for call monitoring, logs, assistant settings, and knowledge/RAG input.
-3. Launch on a Japanese `050` phone number.
-4. Tune VAD/noise handling so ambient noise does not trigger listening too aggressively.
-5. Refresh stale OpenAI API/model usage and general code structure.
+1. Replit/ngrok前提から、再現可能なクラウド運用へ移行する。
+2. 通話監視、ログ、プロンプト、VAD、ナレッジ/RAGを管理できるReact UIを作る。
+3. 日本の `050` 番号で着信運用する。
+4. 周囲音で誤反応しにくいVAD/ノイズ低減設定にする。
+5. OpenAI Realtime API、モデル、イベント形状を2026年4月時点のGA仕様へ更新する。
+6. AIが対応困難と判断した場合、人間オペレーターが画面から通話へ参加できるようにする。
 
-A sixth architectural requirement follows from the operator workflow: when the AI escalates a call, a human operator should be able to join from the React UI and talk to the customer directly.
+## 決定
 
-## Decision
+実装は段階的に進め、`050` 番号の恒久切替は最後に行います。
 
-Modernize incrementally while keeping the phone number cutover last.
+1. 既存のOpenAI APIキーとTwilio番号で、まずローカル通話ループを検証する。
+2. PSTN/050通話の本線は、Twilio Voice -> Node/Fastify -> OpenAI Realtime WebSocket のサーバー側経路を維持する。
+3. React + TypeScriptでオペレーターコンソールを作る。対象は通話監視、ログ、設定、ナレッジ、VAD、引き継ぎ操作。
+4. サーバーからReactへ、WebSocketまたはSSEで通話状態、文字起こし、VAD、AIイベント、パスアップ通知を配信する。
+5. 人間オペレーターのブラウザ通話にはTwilio Voice JavaScript SDKを使う。これはブラウザとTwilio間のWebRTCであり、顧客電話を直接ブラウザへつなぐものではない。
+6. AI/顧客/オペレーターの管理にはTwilio Conferenceを使う。これにより参加、ミュート、削除、保留、将来のコーチングが扱いやすくなる。
+7. Realtimeモデルは `gpt-realtime-1.5` を既定とし、モデル名、音声、文字起こし、VAD、抽出モデルは環境変数または設定として管理する。
+8. 本番はGoogle Cloud Runへデプロイし、秘密情報はSecret Managerへ置く。WebSocket長時間接続のtimeoutと再接続方針を明記する。
 
-1. First restore and validate the current local call path with the existing OpenAI API key and Twilio test/current number. Do not move the `050` number until the end-to-end voice path is verified.
-2. Keep the production phone-call path server-side: Twilio Voice -> Node/Fastify -> OpenAI Realtime over WebSocket. This is the right shape for PSTN/`050` calls.
-3. Add React + TypeScript for the operator console. React owns monitoring, logs, assistant configuration, knowledge/RAG input, VAD profile selection, and handoff controls.
-4. Add a backend event channel from server to React using WebSocket or SSE. It should stream call state, transcripts, AI events, VAD events, escalation requests, and operator actions.
-5. Use Twilio Voice JavaScript SDK for browser-based human operator audio. This introduces WebRTC between the operator browser and Twilio, not between the customer phone and the browser directly.
-6. Use Twilio Conference/call-control semantics for handoff. Prefer a conference-centered design where the customer, AI bridge, and human operator can be managed as participants. This enables join, mute, hold, remove, and potential coaching/monitoring behavior.
-7. Use OpenAI Realtime `gpt-realtime` or the current supported realtime model at implementation time. Model, voice, transcription, VAD, and extraction settings must be configuration, not source-code constants.
-8. Deploy the backend/admin service to Google Cloud Run. Cloud Run supports WebSockets, but long streams require explicit timeout, reconnect behavior, and no end-to-end HTTP/2. Secrets belong in Secret Manager.
-
-## Target Architecture
+## 目標アーキテクチャ
 
 ```text
-050 customer call
+050顧客通話
   -> Twilio Voice / Conference
   -> backend Twilio webhook + Media Stream WebSocket
   -> OpenAI Realtime WebSocket
-  -> AI speech response back to Twilio
+  -> AI音声応答をTwilioへ返送
 
-React operator console
-  -> backend REST API for config, knowledge, sessions, logs
-  -> backend event stream for live call state
-  -> Twilio Voice JS SDK for operator WebRTC softphone
-  -> Twilio Conference participant control through backend
+Reactオペレーターコンソール
+  -> 設定、ナレッジ、通話履歴のREST API
+  -> 通話状態のリアルタイムイベント
+  -> Twilio Voice SDKによるWebRTCソフトフォン
+  -> backend経由のConference参加者制御
 ```
 
-## Rollout Order
+## ロールアウト順序
 
-1. Local baseline: fix startup blockers, validate OpenAI key, validate current Twilio/ngrok call path.
-2. API refresh: update Realtime model/session shape, transcription settings, structured extraction, and config loading.
-3. VAD tuning: add named profiles, noise reduction settings, speech event logging, and comparison tests.
-4. React console: create authenticated UI for live call monitoring, logs, assistant settings, VAD profile, and knowledge input.
-5. Handoff: implement AI escalation events, operator notification, Twilio Voice SDK browser softphone, and Conference participant controls.
-6. Cloud Run: containerize, wire Secret Manager, configure WebSocket timeout/reconnect posture, and add deployment docs.
-7. Japanese launch: switch the `050` number webhook to Cloud Run only after the verified production URL is stable.
+1. Wave 1: ローカル起動、OpenAI Realtime、Twilio Media Streams、050実着信を検証する。
+2. Wave 2: TypeScript化、設定スキーマ、Realtime GA仕様、VADプロファイルを整備する。
+3. Wave 3: React管理画面、通話状態イベント、ログ表示、設定編集を実装する。
+4. Wave 4: RAG/ナレッジ投入、参照元表示、監査ログを実装する。
+5. Wave 5: Twilio Voice SDKとConferenceで人間への引き継ぎを実装する。
+6. Wave 6: Cloud Run、Secret Manager、監視、署名検証を整備する。
+7. Wave 7: 050番号を本番URLへ恒久切替する。
 
-## Acceptance Criteria
+## 受け入れ条件
 
-- A local test call works before cloud deployment starts.
-- All model names and realtime/session/VAD settings are configurable.
-- React can show live call state and transcript updates.
-- Operators can receive an AI escalation request and join the customer call from the browser.
-- Cloud Run deployment can handle Twilio WebSocket traffic for expected call duration.
-- The `050` number is switched only after Cloud Run, Twilio webhook verification, and Japanese call-flow tests pass.
+- Cloud Run前に、ローカルで実050着信からOpenAI Realtime音声応答まで確認済みである。
+- Realtimeの `session.update` はGA形状を使う。
+- React画面で通話状態と文字起こしを確認できる。
+- AIのパスアップを受け、人間オペレーターがブラウザから参加できる。
+- Cloud Run上で想定通話時間のWebSocket接続が維持できる。
+- 050番号は本番URL、署名検証、日本語通話テスト完了後に切り替える。
 
-## Consequences
+## 影響
 
-- This is a larger refactor than updating model strings, but it preserves the safest launch order.
-- Browser WebRTC is introduced for human operators, while server WebSockets remain the phone AI path.
-- Conference-based handoff adds Twilio complexity but avoids brittle one-off call transfer behavior.
-- The admin/RAG layer requires authentication, persistence, audit logging, and privacy controls.
+- 単なるモデル名変更より大きな改修になるが、プロトタイプの前提を本番へ持ち込まずに済む。
+- 電話AI本線はWebSocket、人間オペレーター参加はWebRTCという役割分担になる。
+- Conference制御によりTwilio実装は複雑になるが、引き継ぎや将来拡張が安定する。
+- 管理画面とRAGにより、認証、永続化、監査、個人情報保護が必須になる。
 
-## References
+## 参考
 
 - OpenAI Realtime model: https://developers.openai.com/api/docs/models/gpt-realtime
 - OpenAI Realtime VAD: https://developers.openai.com/api/docs/guides/realtime-vad
-- OpenAI Realtime WebRTC: https://platform.openai.com/docs/guides/realtime-webrtc
+- OpenAI Realtime WebSocket: https://developers.openai.com/api/docs/guides/realtime-websocket
 - Google Cloud Run WebSockets: https://docs.cloud.google.com/run/docs/triggering/websockets
-- Google Cloud Run secrets: https://docs.cloud.google.com/run/docs/configuring/services/secrets
 - Twilio Media Streams: https://www.twilio.com/docs/voice/media-streams
 - Twilio Voice JavaScript SDK: https://www.twilio.com/docs/voice/client/javascript
-- Twilio Voice Conference: https://www.twilio.com/docs/voice/conference
+- Twilio Conference: https://www.twilio.com/docs/voice/conference

--- a/docs/adr/0002-operator-console-human-handoff.md
+++ b/docs/adr/0002-operator-console-human-handoff.md
@@ -1,22 +1,22 @@
-# ADR 0002: Operator Console and Human Handoff
+# ADR 0002: オペレーターコンソールと人間への引き継ぎ
 
-- Status: Proposed
-- Date: 2026-04-26
-- Scope: React console, live monitoring, AI escalation, operator WebRTC, Twilio Conference control
+- ステータス: 提案中
+- 日付: 2026-04-26
+- 対象: React管理画面、通話監視、AIパスアップ、オペレーターWebRTC、Twilio Conference制御
 
-## Context
+## 背景
 
-The desired operating model is not a fully autonomous voice bot. Operators should be able to watch AI-handled customer calls, see the transcript and AI state, and join the call when the AI requests help or the operator decides to intervene.
+このシステムは完全自律の音声ボットではなく、日本のコールセンターでAIと人間が協調する前提です。AIが対応し、必要に応じて人間オペレーターへパスアップし、オペレーターが同じ画面から顧客通話へ参加できる必要があります。
 
-The current code has no frontend, no live event API, no operator identity, and no call-control model. Adding React alone solves only the display/configuration problem. Human voice takeover requires browser audio and telephony call control.
+現行コードにはフロントエンド、リアルタイム通話イベント、オペレーターID、通話制御がありません。Reactだけでは通話参加は実現できないため、Twilio Voice SDKとConference制御が必要です。
 
-## Decision
+## 決定
 
-Build the operator experience as a React + TypeScript console backed by a Fastify API. Use Twilio Voice JavaScript SDK for the operator softphone and Twilio Conference for multi-party call management.
+React + TypeScriptでオペレーターコンソールを作り、Fastify backendが設定、ログ、Twilio token、Conference制御を提供します。オペレーターの音声参加にはTwilio Voice JavaScript SDKを使います。
 
-The AI remains connected through the backend using Twilio Media Streams and OpenAI Realtime WebSocket. The operator joins through Twilio Voice SDK, which uses WebRTC between the browser and Twilio. Backend APIs control conference participants.
+AIは従来通りbackendからTwilio Media StreamsとOpenAI Realtime WebSocketへ接続します。オペレーターはブラウザからTwilioへWebRTC接続し、backendがConference参加者を制御します。
 
-## Handoff States
+## 引き継ぎ状態
 
 ```text
 ai_active
@@ -28,42 +28,41 @@ ai_active
   -> call_completed
 ```
 
-Manual operator intervention can move directly from `ai_active` to `operator_ringing`.
+オペレーターが手動で介入する場合は、`ai_active` から `operator_ringing` へ直接遷移できます。
 
-## Console Capabilities
+## コンソール機能
 
-- Live call list with status, elapsed time, customer number, AI state, and escalation status.
-- Transcript panel with user/AI turns and timing.
-- VAD/realtime event panel for debugging speech start/stop, response creation, and interruptions.
-- Assistant settings: instructions, first message, voice, model, transcription model, VAD profile.
-- Knowledge/RAG management: upload, indexing status, active/inactive state, and source preview.
-- Handoff controls: acknowledge escalation, join call, mute AI, remove AI, end operator leg, end call.
+- 通話一覧: 状態、経過時間、顧客番号、AI状態、パスアップ状態
+- 通話詳細: ユーザー/AI発話、文字起こし、タイムライン
+- デバッグ: VAD、Realtimeイベント、割り込み、応答生成
+- 設定: instructions、初回発話、voice、model、transcription、VAD profile
+- ナレッジ: アップロード、インデックス状態、有効/無効、参照元確認
+- 引き継ぎ: パスアップ確認、通話参加、AIミュート、AI退出、オペレーター切断、通話終了
 
-## Backend Capabilities
+## backend機能
 
-- REST APIs for settings, knowledge, session records, and Twilio access-token generation.
-- Live event stream over WebSocket or SSE for call state and transcript updates.
-- Twilio webhook signature verification.
-- Twilio Conference participant APIs for join/mute/hold/remove operations.
-- Audit log for settings changes and handoff actions.
+- 設定、ナレッジ、通話記録、Twilio access tokenのREST API
+- 通話状態と文字起こしのWebSocket/SSE配信
+- Twilio webhook署名検証
+- Conference参加者の追加、ミュート、保留、削除
+- 設定変更と引き継ぎ操作の監査ログ
 
-## Security and Privacy
+## セキュリティと個人情報
 
-- The console must require authentication before exposing call logs or softphone tokens.
-- Twilio Voice access tokens must be short-lived and scoped to an operator identity.
-- Full transcripts and phone numbers should not be printed in production logs by default.
-- Knowledge uploads need validation, size limits, and deletion/disable controls.
+- 管理画面は認証必須にする。
+- Twilio Voice tokenは短命かつオペレーターIDに紐づける。
+- 本番ログで全文トランスクリプトや電話番号をデフォルト出力しない。
+- ナレッジ文書にはサイズ制限、検証、削除、無効化を用意する。
 
-## Open Questions
+## 未決事項
 
-- Which identity provider should protect the admin console for the first release?
-- Should AI remain silently listening after operator takeover, or be removed from the conference?
-- Is coaching mode required, where a supervisor/AI can speak to the operator without the customer hearing it?
-- What persistence layer should store settings, knowledge metadata, transcripts, and audit logs?
+- 初期リリースの認証基盤を何にするか。
+- 人間引き継ぎ後にAIを退出させるか、無音で聞かせ続けるか。
+- 顧客には聞こえないコーチングモードを必要とするか。
+- 設定、ナレッジ、通話履歴、監査ログの永続化先を何にするか。
 
-## References
+## 参考
 
 - Twilio Voice JavaScript SDK: https://www.twilio.com/docs/voice/client/javascript
 - Twilio Voice SDK reference components: https://www.twilio.com/docs/voice/sdks/javascript/reference-components
 - Twilio Voice Conference: https://www.twilio.com/docs/voice/conference
-- OpenAI Realtime WebRTC: https://platform.openai.com/docs/guides/realtime-webrtc

--- a/docs/implementation-plan.md
+++ b/docs/implementation-plan.md
@@ -1,86 +1,96 @@
-# Implementation Plan
+# 実装計画
 
-This plan turns the modernization ADRs into GitHub implementation epics and sub-issues.
+この文書は、2026年版プロダクション移行ADRをGitHub issueと実装Waveへ落とし込むための計画です。
 
-## Principles
+## 原則
 
-- Keep the `050` number cutover last.
-- Validate the current local voice loop before cloud deployment.
-- Keep PSTN voice traffic server-side with Twilio Media Streams and OpenAI Realtime WebSocket.
-- Use React for the operator console and Twilio Voice SDK WebRTC for human operator participation.
-- Treat settings, models, VAD, knowledge, and phone routing as configuration.
+- `050` 番号の恒久切替は最後に行う。
+- Cloud Run前に、ローカルで実050着信の音声ループを検証する。
+- 電話AI本線はTwilio Media StreamsとOpenAI Realtime WebSocketでサーバー側に置く。
+- Reactは監視、設定、ナレッジ、引き継ぎのために使う。
+- 人間オペレーターの通話参加にはTwilio Voice SDKのWebRTCを使う。
+- モデル、VAD、音声、電話番号、ナレッジは設定として扱う。
 
-## Epic Structure
+## エピック
 
-### Epic: 2026 Production Modernization
+### Epic: 2026年版プロダクション移行
 
 GitHub tracking issue: #20
 
-Owns the full migration from prototype to production-ready voice assistant.
+プロトタイプを、日本のコールセンターで使える音声AI受付システムへ移行します。
 
-Sub-issues:
+サブissue:
 
-1. #8 Local baseline and smoke tests.
-2. #6 TypeScript/backend module split.
-3. #7 OpenAI Realtime API/model refresh.
-4. #10 VAD and noise-reduction profiles.
-5. #9 Twilio local/current-number validation.
-6. #12 React operator console shell.
-7. #11 Live call event stream and call-state store.
-8. #14 Knowledge/RAG ingestion and retrieval.
-9. #13 Twilio Voice SDK operator softphone.
-10. #15 AI escalation detection and handoff workflow.
-11. #17 Twilio Conference participant control.
-12. #16 Cloud Run deployment and Secret Manager.
-13. #19 Observability, privacy, and audit logs.
-14. #18 Japanese `050` number cutover.
+1. #8 ローカル起動とスモークテスト
+2. #6 TypeScript化とbackend分割
+3. #7 OpenAI Realtime API/モデル更新
+4. #10 VAD/ノイズ低減プロファイル
+5. #9 Twilioローカル/現行番号検証
+6. #12 Reactオペレーターコンソール
+7. #11 通話状態イベントストリーム
+8. #14 ナレッジ/RAG投入と検索
+9. #13 Twilio Voice SDKソフトフォン
+10. #15 AIパスアップ判定と通知
+11. #17 Twilio Conference参加者制御
+12. #16 Cloud RunとSecret Manager
+13. #19 ログ、監査、プライバシー制御
+14. #18 日本の050番号本番切替
 
-## Milestones
+## Wave
 
-### Milestone 1: Local Voice Loop
+### Wave 1: ローカル音声ループ検証
 
-- App starts locally without import/dependency errors.
-- Existing OpenAI API key can create a realtime session.
-- Existing/current Twilio number or test TwiML app can reach local ngrok endpoint.
-- A call can complete one AI turn.
+- ローカルサーバーが起動する。
+- OpenAI APIキーでRealtime GAセッションが作成できる。
+- Twilio Media Streams互換のWebSocket経路が通る。
+- ngrok経由で050番号からローカルへ着信できる。
+- AI音声応答がTwilioへ返る。
 
-### Milestone 2: Modern Backend
+### Wave 2: backend基盤更新
 
-- TypeScript project structure is in place.
-- Config schema validates required secrets and model settings.
-- Realtime session code uses supported model/session settings.
-- VAD profiles are configurable and testable.
+- TypeScript化する。
+- 設定スキーマを追加する。
+- Realtimeモデル、音声、文字起こし、VADを設定化する。
+- 最低限のテスト基盤を整える。
 
-### Milestone 3: Operator Console
+### Wave 3: React管理画面
 
-- React console is authenticated.
-- Live call list and transcript panel receive backend events.
-- Assistant settings and knowledge documents can be managed from UI.
+- 認証付きの管理画面を作る。
+- 通話一覧、通話詳細、文字起こし、Realtimeイベントを表示する。
+- assistant設定とVADプロファイルを編集できるようにする。
 
-### Milestone 4: Human Handoff
+### Wave 4: ナレッジ/RAG
 
-- AI can emit an escalation event.
-- Operator receives notification in the console.
-- Operator joins through Twilio Voice SDK.
-- Backend can mute/remove AI and manage conference participants.
+- ナレッジ文書を投入できる。
+- インデックス状態を表示する。
+- AI応答に参照元を紐づける。
 
-### Milestone 5: Production Launch
+### Wave 5: 人間への引き継ぎ
 
-- Cloud Run service is deployed with Secret Manager.
-- WebSocket timeout/reconnect posture is documented and tested.
-- Webhook signature verification is enabled.
-- `050` number points to the production Cloud Run URL.
-- Japanese call-flow test passes.
+- AIがパスアップイベントを出す。
+- オペレーターがReact画面で通知を受ける。
+- Twilio Voice SDKでブラウザから通話へ参加する。
+- Twilio ConferenceでAIのミュート/退出を制御する。
 
-## Initial Work Order
+### Wave 6: Cloud Run本番基盤
 
-1. Fix local startup and dependency issues.
-2. Add a minimal smoke-test script for `/`, `/incoming-call`, and Realtime connection configuration.
-3. Update OpenAI Realtime model/session config behind environment variables.
-4. Add VAD profile config and speech-event logging.
-5. Introduce TypeScript structure without changing external behavior.
-6. Add React console skeleton and backend session-event stream.
-7. Add Twilio Voice SDK operator token endpoint and browser softphone proof of concept.
-8. Move call flow to Conference-based handoff.
-9. Deploy to Cloud Run staging.
-10. Switch the `050` number after staging call tests pass.
+- Docker化する。
+- Secret Managerへ秘密情報を移す。
+- WebSocket timeoutと再接続方針を検証する。
+- webhook署名検証を有効化する。
+
+### Wave 7: 050番号本番切替
+
+- 本番Cloud Run URLへ050番号を向ける。
+- 日本語通話シナリオを検証する。
+- ロールバック手順を確認する。
+
+## 初期作業順序
+
+1. ローカル起動エラーを修正する。
+2. `/`, `/healthz`, `/incoming-call` のスモーク検証を追加する。
+3. `gpt-realtime-1.5` とGA `session.update` を検証する。
+4. Media Streams互換WebSocketの疑似検証を追加する。
+5. 050実着信をngrok経由で確認する。
+6. 検証証跡をToEとして残す。
+7. 次のPRでTypeScript化と設定スキーマへ進む。

--- a/docs/wave-1-local-voice-loop-plan.md
+++ b/docs/wave-1-local-voice-loop-plan.md
@@ -1,0 +1,82 @@
+# Wave 1 実装計画: ローカル音声ループ検証
+
+## 目的
+
+Cloud Runや050番号の恒久切替へ進む前に、既存のOpenAI APIキーとTwilio経路で、ローカル環境から音声AI会話が成立することを確認します。
+
+親エピック: #20  
+主要issue: #8, #9  
+関連issue: #7, #10, #19
+
+## ブランチ運用
+
+- base branch: `develop`
+- 作業ブランチ: `feature/wave-1-*` または `fix/wave-1-*`
+- マージ先: `develop`
+- `main` はリリース専用
+
+`main` と `develop` は保護されています。変更はPR経由で行います。
+
+## スコープ
+
+### 1. ローカル起動復旧
+
+- `index.js` の重複importや未導入依存など、起動を妨げる問題を修正する。
+- `npm run start`、`npm run check`、`npm test` を整備する。
+- `.env` の必須値が無い場合は明確に失敗させる。
+
+### 2. HTTP/TwiMLスモーク
+
+- `/` または `/healthz` が応答することを確認する。
+- `/incoming-call` がTwilio向けTwiMLを返すことを確認する。
+- 実050番号に依存しないローカルスモークを用意する。
+
+### 3. OpenAI Realtime疎通
+
+- 既存APIキーでOpenAI Realtimeへ接続できることを確認する。
+- 既定モデルは `gpt-realtime-1.5` とする。
+- GA形式の `session.update` が受け入れられることを確認する。
+- APIキーや秘密情報をログへ出さない。
+
+### 4. Twilio Media Streams検証
+
+- Twilio互換のWebSocketイベントをローカルで流す。
+- `connected`、`start`、`media` の処理を確認する。
+- OpenAI Realtimeから返った音声deltaをTwilio向け `media` payloadとして返せることを確認する。
+
+### 5. 050実着信検証
+
+- ngrokでローカルサーバーを公開する。
+- 050番号のWebhookを一時的に `/incoming-call` へ向ける。
+- 実電話から発話し、日本語文字起こしとAI音声応答を確認する。
+- 検証後は必ず元のWebhookへ戻す。
+
+## スコープ外
+
+- Cloud Runデプロイ
+- React管理画面
+- RAG/ナレッジ
+- 人間への引き継ぎ
+- 050番号の恒久切替
+
+## 受け入れ条件
+
+- ローカルサーバーが起動する。
+- `/incoming-call` が有効なTwiMLを返す。
+- `npm run check:realtime` が成功する。
+- `npm run smoke:media-stream` が成功する。
+- 050実着信でOpenAI Realtimeへ接続し、AI音声応答が返る。
+- Twilio webhookを元のURLへ戻したことを確認する。
+
+## 完了成果物
+
+1. 起動修正PR
+2. 最小CI
+3. ローカルスモーク
+4. Realtime疎通スクリプト
+5. Media Streams疑似検証
+6. 050実着信のToE
+
+## 次Waveへの条件
+
+Wave 2は、Wave 1で実050着信の音声ループが成立した後に開始します。次はTypeScript化、設定スキーマ、VADプロファイル、Realtime API周辺の整理を進めます。

--- a/docs/wave-1-verification-toe.md
+++ b/docs/wave-1-verification-toe.md
@@ -1,0 +1,214 @@
+# Wave 1 Verification ToE
+
+ToE means test evidence for the Wave 1 local voice loop. Use this document to reproduce and record the minimum proof that the current Twilio -> local Node -> OpenAI Realtime -> Twilio path works before Cloud Run or permanent `050` number cutover.
+
+## Scope
+
+This verifies:
+
+- Local server startup.
+- Local HTTP and TwiML endpoints.
+- OpenAI Realtime GA WebSocket session creation and `session.update`.
+- Twilio Media Streams-compatible WebSocket audio return path.
+- Temporary real `050` inbound call through ngrok.
+
+This does not verify Cloud Run, React operator UI, RAG, human handoff, or production webhook signature validation.
+
+## Prerequisites
+
+- Node.js 22 or compatible Node runtime.
+- Valid `.env` with `OPENAI_API_KEY`.
+- Twilio CLI logged in and active.
+- ngrok configured.
+- Access to the Twilio `050` number.
+
+Confirm Twilio profile and numbers:
+
+```bash
+twilio profiles:list
+twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,friendlyName,voiceUrl,voiceMethod --limit 20
+```
+
+Known Wave 1 test number:
+
+```text
++815017929351
+```
+
+## Local Checks
+
+Install and run syntax checks:
+
+```bash
+npm ci
+npm test
+```
+
+Expected:
+
+```text
+node --check index.js
+```
+
+Start the local server:
+
+```bash
+npm run start
+```
+
+In a second terminal, verify local endpoints:
+
+```bash
+SMOKE_BASE_URL=http://127.0.0.1:5050 npm run smoke:local
+```
+
+Expected:
+
+```text
+ok - root endpoint
+ok - health endpoint
+ok - incoming-call TwiML
+```
+
+## OpenAI Realtime Check
+
+```bash
+npm run check:realtime
+```
+
+Expected:
+
+```text
+ok - connected to OpenAI Realtime model gpt-realtime-1.5
+ok - received session.created
+ok - session.update accepted
+```
+
+## Local Media Stream Check
+
+With the local server still running:
+
+```bash
+npm run smoke:media-stream
+```
+
+Expected:
+
+```text
+ok - connected to local media stream WebSocket
+ok - received outbound media payload from server
+```
+
+This confirms that a Twilio Media Streams-compatible client can connect and receive an outbound audio payload generated through OpenAI Realtime.
+
+## ngrok Public Endpoint Check
+
+Start ngrok:
+
+```bash
+ngrok http 5050
+```
+
+Fetch the public URL:
+
+```bash
+curl -s http://127.0.0.1:4040/api/tunnels
+```
+
+Set:
+
+```bash
+export NGROK_URL=https://your-ngrok-host.ngrok-free.app
+```
+
+Verify public endpoints:
+
+```bash
+curl -sS -i "$NGROK_URL/healthz"
+curl -sS -i -X POST "$NGROK_URL/incoming-call"
+```
+
+Expected:
+
+- `/healthz` returns HTTP 200 and `{"status":"ok"}`.
+- `/incoming-call` returns TwiML with `wss://.../media-stream`.
+
+## Temporary `050` Call Test
+
+Record the current webhook before changing it:
+
+```bash
+twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,voiceUrl,voiceMethod --limit 20
+```
+
+Temporarily point the `050` number to ngrok:
+
+```bash
+twilio api:core:incoming-phone-numbers:update \
+  --sid PNd8122ab1cccb51d2ae53fca20eeb5a02 \
+  --voice-url "$NGROK_URL/incoming-call" \
+  --voice-method POST \
+  --properties sid,phoneNumber,voiceUrl,voiceMethod
+```
+
+Call `050-1792-9351`.
+
+Expected server logs:
+
+```text
+Incoming call
+Client connected
+Incoming stream has started ...
+Connected to the OpenAI Realtime API
+Received event: session.created
+Received event: session.updated
+Received event: input_audio_buffer.speech_started
+Received event: input_audio_buffer.speech_stopped
+Received event: conversation.item.input_audio_transcription.completed
+Received event: response.output_audio_transcript.done
+Received event: response.done
+```
+
+Evidence from the first successful run:
+
+```text
+transcript: こんにちは
+transcript: どんなことがあなたできるんですか?
+```
+
+## Cleanup
+
+Restore the previous webhook. During the first Wave 1 run, the restore target was:
+
+```bash
+twilio api:core:incoming-phone-numbers:update \
+  --sid PNd8122ab1cccb51d2ae53fca20eeb5a02 \
+  --voice-url https://demo.twilio.com/welcome/voice/ \
+  --voice-method POST \
+  --properties sid,phoneNumber,voiceUrl,voiceMethod
+```
+
+Stop local processes:
+
+```bash
+pkill -f "node index.js"
+pkill -f "ngrok http 5050"
+```
+
+Confirm the number has been restored:
+
+```bash
+twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,voiceUrl,voiceMethod --limit 20
+```
+
+## Pass Criteria
+
+Wave 1 passes when:
+
+- CI `Node checks` passes.
+- `npm test` passes locally.
+- `npm run check:realtime` passes.
+- `npm run smoke:local` passes.
+- `npm run smoke:media-stream` passes.
+- A real `050` inbound call reaches OpenAI Realtime and receives audio back.
+- The temporary Twilio webhook is restored after testing.

--- a/docs/wave-1-verification-toe.md
+++ b/docs/wave-1-verification-toe.md
@@ -1,68 +1,74 @@
-# Wave 1 Verification ToE
+# Wave 1 検証ToE
 
-ToE means test evidence for the Wave 1 local voice loop. Use this document to reproduce and record the minimum proof that the current Twilio -> local Node -> OpenAI Realtime -> Twilio path works before Cloud Run or permanent `050` number cutover.
+ToEはTest of Evidence、つまり検証証跡です。この文書は、Cloud Runや050番号の恒久切替に進む前に、Twilio -> ローカルNode -> OpenAI Realtime -> Twilio の音声ループが成立することを再現・記録するための手順です。
 
-## Scope
+## 対象
 
-This verifies:
+検証するもの:
 
-- Local server startup.
-- Local HTTP and TwiML endpoints.
-- OpenAI Realtime GA WebSocket session creation and `session.update`.
-- Twilio Media Streams-compatible WebSocket audio return path.
-- Temporary real `050` inbound call through ngrok.
+- ローカルサーバー起動
+- ローカルHTTP/TwiMLエンドポイント
+- OpenAI Realtime GA WebSocket接続と `session.update`
+- Twilio Media Streams互換のWebSocket音声返送
+- ngrok経由の050実着信
 
-This does not verify Cloud Run, React operator UI, RAG, human handoff, or production webhook signature validation.
+対象外:
 
-## Prerequisites
+- Cloud Run
+- React管理画面
+- RAG/ナレッジ
+- 人間への引き継ぎ
+- 本番のTwilio webhook署名検証
 
-- Node.js 22 or compatible Node runtime.
-- Valid `.env` with `OPENAI_API_KEY`.
-- Twilio CLI logged in and active.
-- ngrok configured.
-- Access to the Twilio `050` number.
+## 前提
 
-Confirm Twilio profile and numbers:
+- Node.js 22系
+- `OPENAI_API_KEY` を含む `.env`
+- Twilio CLIログイン済み
+- ngrok設定済み
+- Twilioの050番号へアクセスできること
+
+Twilio profileと番号を確認します。
 
 ```bash
 twilio profiles:list
 twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,friendlyName,voiceUrl,voiceMethod --limit 20
 ```
 
-Known Wave 1 test number:
+Wave 1で確認した050番号:
 
 ```text
 +815017929351
 ```
 
-## Local Checks
+## ローカル確認
 
-Install and run syntax checks:
+依存関係を入れて構文チェックを実行します。
 
 ```bash
 npm ci
 npm test
 ```
 
-Expected:
+期待結果:
 
 ```text
 node --check index.js
 ```
 
-Start the local server:
+サーバーを起動します。
 
 ```bash
 npm run start
 ```
 
-In a second terminal, verify local endpoints:
+別ターミナルでローカルエンドポイントを確認します。
 
 ```bash
 SMOKE_BASE_URL=http://127.0.0.1:5050 npm run smoke:local
 ```
 
-Expected:
+期待結果:
 
 ```text
 ok - root endpoint
@@ -70,13 +76,13 @@ ok - health endpoint
 ok - incoming-call TwiML
 ```
 
-## OpenAI Realtime Check
+## OpenAI Realtime確認
 
 ```bash
 npm run check:realtime
 ```
 
-Expected:
+期待結果:
 
 ```text
 ok - connected to OpenAI Realtime model gpt-realtime-1.5
@@ -84,64 +90,64 @@ ok - received session.created
 ok - session.update accepted
 ```
 
-## Local Media Stream Check
+## Media Streams互換確認
 
-With the local server still running:
+ローカルサーバー起動中に実行します。
 
 ```bash
 npm run smoke:media-stream
 ```
 
-Expected:
+期待結果:
 
 ```text
 ok - connected to local media stream WebSocket
 ok - received outbound media payload from server
 ```
 
-This confirms that a Twilio Media Streams-compatible client can connect and receive an outbound audio payload generated through OpenAI Realtime.
+これは、Twilio Media Streams互換クライアントが接続し、OpenAI Realtimeで生成された音声payloadを受け取れることを確認します。
 
-## ngrok Public Endpoint Check
+## ngrok公開URL確認
 
-Start ngrok:
+ngrokを起動します。
 
 ```bash
 ngrok http 5050
 ```
 
-Fetch the public URL:
+公開URLを取得します。
 
 ```bash
 curl -s http://127.0.0.1:4040/api/tunnels
 ```
 
-Set:
+環境変数へ入れます。
 
 ```bash
 export NGROK_URL=https://your-ngrok-host.ngrok-free.app
 ```
 
-Verify public endpoints:
+公開URLを確認します。
 
 ```bash
 curl -sS -i "$NGROK_URL/healthz"
 curl -sS -i -X POST "$NGROK_URL/incoming-call"
 ```
 
-Expected:
+期待結果:
 
-- `/healthz` returns HTTP 200 and `{"status":"ok"}`.
-- `/incoming-call` returns TwiML with `wss://.../media-stream`.
+- `/healthz` がHTTP 200と `{"status":"ok"}` を返す。
+- `/incoming-call` が `wss://.../media-stream` を含むTwiMLを返す。
 
-## Temporary `050` Call Test
+## 050一時着信テスト
 
-Record the current webhook before changing it:
+変更前のWebhookを必ず記録します。
 
 ```bash
 twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,voiceUrl,voiceMethod --limit 20
 ```
 
-Temporarily point the `050` number to ngrok:
+050番号を一時的にngrokへ向けます。
 
 ```bash
 twilio api:core:incoming-phone-numbers:update \
@@ -151,9 +157,9 @@ twilio api:core:incoming-phone-numbers:update \
   --properties sid,phoneNumber,voiceUrl,voiceMethod
 ```
 
-Call `050-1792-9351`.
+`050-1792-9351` へ電話します。
 
-Expected server logs:
+期待ログ:
 
 ```text
 Incoming call
@@ -169,16 +175,16 @@ Received event: response.output_audio_transcript.done
 Received event: response.done
 ```
 
-Evidence from the first successful run:
+初回成功時の証跡:
 
 ```text
 transcript: こんにちは
 transcript: どんなことがあなたできるんですか?
 ```
 
-## Cleanup
+## 後片付け
 
-Restore the previous webhook. During the first Wave 1 run, the restore target was:
+必ずWebhookを戻します。初回Wave 1検証時の戻し先は次の通りです。
 
 ```bash
 twilio api:core:incoming-phone-numbers:update \
@@ -188,27 +194,27 @@ twilio api:core:incoming-phone-numbers:update \
   --properties sid,phoneNumber,voiceUrl,voiceMethod
 ```
 
-Stop local processes:
+ローカルプロセスを停止します。
 
 ```bash
 pkill -f "node index.js"
 pkill -f "ngrok http 5050"
 ```
 
-Confirm the number has been restored:
+番号設定が戻っていることを確認します。
 
 ```bash
 twilio api:core:incoming-phone-numbers:list --properties sid,phoneNumber,voiceUrl,voiceMethod --limit 20
 ```
 
-## Pass Criteria
+## 合格基準
 
-Wave 1 passes when:
+Wave 1は次を満たしたら合格です。
 
-- CI `Node checks` passes.
-- `npm test` passes locally.
-- `npm run check:realtime` passes.
-- `npm run smoke:local` passes.
-- `npm run smoke:media-stream` passes.
-- A real `050` inbound call reaches OpenAI Realtime and receives audio back.
-- The temporary Twilio webhook is restored after testing.
+- CIの `Node checks` が成功する。
+- ローカルで `npm test` が成功する。
+- `npm run check:realtime` が成功する。
+- `npm run smoke:local` が成功する。
+- `npm run smoke:media-stream` が成功する。
+- 050実着信でOpenAI Realtimeへ接続し、AI音声応答が返る。
+- テスト後にTwilio webhookを元に戻している。


### PR DESCRIPTION
## 概要

- Wave 1の検証ToEを日本語で追加しました。
- Wave 1の実装計画、ADR、実装計画、AGENTSを日本のコールセンター運用前提の日本語ドキュメントへ更新しました。
- GitHub issue本文も日本語へ更新済みです。

## 検証

- `npm test` 成功

Refs #8
Refs #9
Refs #20
