### PR TITLE
Cloud Run常時起動基盤とCI/CDを追加

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+npm-debug.log
+.git
+.github
+.env
+.env.*
+coverage
+*.log
+docs

--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -1,0 +1,52 @@
+name: Deploy Cloud Run
+
+on:
+  push:
+    branches:
+      - develop
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  PROJECT_ID: aipartner-426616
+  REGION: asia-northeast1
+  SERVICE: speech-assistant-realtime
+  DEPLOYER_SERVICE_ACCOUNT: speech-assistant-deployer@aipartner-426616.iam.gserviceaccount.com
+  WORKLOAD_IDENTITY_PROVIDER: projects/639959525777/locations/global/workloadIdentityPools/github-actions/providers/github
+
+jobs:
+  deploy:
+    name: Deploy to Cloud Run
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.DEPLOYER_SERVICE_ACCOUNT }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy
+        run: |
+          gcloud run deploy "$SERVICE" \
+            --project "$PROJECT_ID" \
+            --region "$REGION" \
+            --source . \
+            --allow-unauthenticated \
+            --min-instances 1 \
+            --max-instances 5 \
+            --concurrency 20 \
+            --timeout 3600 \
+            --cpu 1 \
+            --memory 512Mi \
+            --set-secrets OPENAI_API_KEY=openai-api-key:latest \
+            --set-env-vars REALTIME_MODEL=gpt-realtime-1.5,TRANSCRIPTION_MODEL=gpt-4o-transcribe,EXTRACTION_MODEL=gpt-5.4-mini,EXTRACTION_ENABLED=false,VOICE=marin,AUDIO_FORMAT=audio/pcmu,AUDIO_NOISE_REDUCTION=near_field,VAD_TYPE=server_vad,VAD_THRESHOLD=0.65,VAD_PREFIX_PADDING_MS=300,VAD_SILENCE_DURATION_MS=700,VAD_EAGERNESS=low,LOG_TRANSCRIPTS=false,LOG_OPENAI_RESPONSES=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-slim
+
+WORKDIR /app
+
+ENV NODE_ENV=production
+
+COPY package*.json ./
+RUN npm ci --omit=dev
+
+COPY . .
+
+CMD ["npm", "run", "start"]

--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -1,0 +1,62 @@
+# Cloud Runデプロイ手順
+
+## 目的
+
+ローカル検証済みのNode/Fastify + Twilio Media Streams + OpenAI Realtime構成を、Google Cloud Run上で常時起動できる最小基盤として動かします。
+
+## 前提
+
+- GCP project: `aipartner-426616`
+- Cloud Run region: `asia-northeast1`
+- Cloud Run service: `speech-assistant-realtime`
+- Secret Manager secret: `openai-api-key`
+- GitHub repository: `Cor-Incorporated/speech-assistant-openai-realtime-api-node`
+
+## 手動デプロイ
+
+```bash
+gcloud run deploy speech-assistant-realtime \
+  --project aipartner-426616 \
+  --region asia-northeast1 \
+  --source . \
+  --allow-unauthenticated \
+  --min-instances 1 \
+  --max-instances 5 \
+  --concurrency 20 \
+  --timeout 3600 \
+  --cpu 1 \
+  --memory 512Mi \
+  --set-secrets OPENAI_API_KEY=openai-api-key:latest \
+  --set-env-vars REALTIME_MODEL=gpt-realtime-1.5,TRANSCRIPTION_MODEL=gpt-4o-transcribe,EXTRACTION_MODEL=gpt-5.4-mini,EXTRACTION_ENABLED=false,VOICE=marin,AUDIO_FORMAT=audio/pcmu,AUDIO_NOISE_REDUCTION=near_field,VAD_TYPE=server_vad,VAD_THRESHOLD=0.65,VAD_PREFIX_PADDING_MS=300,VAD_SILENCE_DURATION_MS=700,VAD_EAGERNESS=low,LOG_TRANSCRIPTS=false,LOG_OPENAI_RESPONSES=false
+```
+
+## CI/CD
+
+`.github/workflows/deploy-cloud-run.yml` は `develop` へのpush時、または手動実行時にCloud Runへデプロイします。
+
+認証はGitHub Actions OIDC + Google Cloud Workload Identity Federationを使います。長期のGCPサービスアカウントキーはGitHubへ保存しません。
+
+## Twilio設定
+
+Cloud Runデプロイ後、サービスURLが次のように得られます。
+
+```bash
+gcloud run services describe speech-assistant-realtime \
+  --project aipartner-426616 \
+  --region asia-northeast1 \
+  --format='value(status.url)'
+```
+
+一時検証ではTwilio番号のVoice URLを次の形式にします。
+
+```text
+https://<cloud-run-url>/incoming-call
+```
+
+本番の050番号恒久切替は、Cloud Run上で `/health`、`/incoming-call`、実通話、ログ、署名検証を確認してから行います。
+
+## 注意点
+
+- `--min-instances 1` により常時待機します。費用が発生するため、不要になったら0へ戻します。
+- Cloud RunのWebSocketはリクエストtimeoutの影響を受けます。現時点では `3600` 秒に設定します。
+- 本番ではTwilio webhook署名検証を追加してから050番号を恒久切替します。

--- a/index.js
+++ b/index.js
@@ -111,6 +111,10 @@ fastify.get('/healthz', async (request, reply) => {
     reply.send({ status: 'ok' });
 });
 
+fastify.get('/health', async (request, reply) => {
+    reply.send({ status: 'ok' });
+});
+
 // Twilioが着信を処理するルート
 fastify.all('/incoming-call', async (request, reply) => {
     console.log('Incoming call');
@@ -282,7 +286,7 @@ fastify.register(async (fastify) => {
 });
 
 // サーバーを起動
-fastify.listen({ port: PORT_NUMBER }, (err) => {
+fastify.listen({ port: PORT_NUMBER, host: '0.0.0.0' }, (err) => {
     if (err) {
         console.error(err);
         process.exit(1);

--- a/scripts/smoke-local.js
+++ b/scripts/smoke-local.js
@@ -1,4 +1,4 @@
-const baseUrl = process.env.SMOKE_BASE_URL || 'http://localhost:5050';
+const baseUrl = process.env.SMOKE_BASE_URL || 'http://127.0.0.1:5050';
 const smokeUrl = new URL(baseUrl);
 
 async function assertOk(name, check) {
@@ -22,7 +22,7 @@ await assertOk('root endpoint', async () => {
 });
 
 await assertOk('health endpoint', async () => {
-    const response = await fetch(`${baseUrl}/healthz`);
+    const response = await fetch(`${baseUrl}/health`);
     if (!response.ok) throw new Error(`Expected 2xx, got ${response.status}`);
     const body = await response.json();
     if (body.status !== 'ok') throw new Error('Unexpected health response body');


### PR DESCRIPTION
## 概要
- Cloud Run向けのDockerfileとdockerignoreを追加
- develop push時にCloud Runへ自動デプロイするGitHub Actionsを追加
- Cloud Run向けにFastifyを0.0.0.0で待ち受け、/healthを監視用エンドポイントとして追加
- Cloud Runデプロイ手順を日本語ドキュメント化

## 検証
- npm test
- npm run check:realtime
- npm run smoke:local
- 手動Cloud Runデプロイ: speech-assistant-realtime-00002-w89
- Cloud Run smoke: SMOKE_BASE_URL=https://speech-assistant-realtime-mggisi6odq-an.a.run.app npm run smoke:local

## 注意
- --min-instances 1 で常時起動するため費用が発生します。
- 050番号の恒久切替は、Cloud Run上の実通話検証とTwilio署名検証追加後に行います。