### PR TITLE
Sheets時刻と文字起こし品質を修正

### DIFF
--- a/docs/call-log-firestore-sheets-plan.md
+++ b/docs/call-log-firestore-sheets-plan.md
@@ -21,6 +21,8 @@
 - 顧客名、顧客電話番号、希望日時
 - 切断理由、OpenAI接続エラー
 
+Google Sheetsの開始時刻・終了時刻は日本時間（Asia/Tokyo）の `YYYY-MM-DD HH:mm:ss` 形式で表示します。FirestoreにはUTC ISO文字列とJST表示文字列の両方を保存します。
+
 ## Cloud Run環境変数
 
 ```text
@@ -43,4 +45,3 @@ GOOGLE_SHEETS_SPREADSHEET_ID=11klH3hxWcIWKLOVTBJGxPjATG5aai0a6D8z_F6yUO1A
 ## 次の拡張
 
 Sheets確認後、React管理画面でFirestoreを直接表示します。分析用途が増えた段階でBigQueryへの同期を追加します。
-

--- a/index.js
+++ b/index.js
@@ -38,6 +38,8 @@ const {
         '必ず自然で丁寧な日本語だけで応答してください。英語では応答しません。',
         '相手の発話が聞き取れない場合は、推測せず「恐れ入ります。もう一度お話しいただけますか」と確認してください。',
         '一度に複数の質問をせず、用件、名前、折り返し電話番号、希望日時などを一つずつ確認してください。',
+        '氏名は聞こえた読みをそのままカタカナで確認してください。一般的な漢字名へ勝手に変換しないでください。',
+        '氏名が少しでも不確かな場合は「お名前の読みをカタカナで確認させてください」と聞き返してください。',
         '会話を勝手に終了せず、必要に応じて担当者へ引き継ぐ旨を伝えてください。',
         'まだ社名や業務ナレッジが未設定のため、断定できない内容は「確認して折り返します」と案内してください。'
     ].join('\n'),
@@ -75,6 +77,18 @@ const escapeXml = (value = '') => String(value)
     .replaceAll("'", '&apos;')
     .replaceAll('<', '&lt;')
     .replaceAll('>', '&gt;');
+
+const appendTurn = (session, role, text) => {
+    const normalizedText = String(text || '').trim();
+    if (!normalizedText || normalizedText === 'Agent message not found') return;
+
+    const lastTurn = session.turns.at(-1);
+    if (lastTurn?.role === role && lastTurn.text === normalizedText) return;
+
+    const label = role === 'agent' ? 'Agent' : 'User';
+    session.transcript += `${label}: ${normalizedText}\n`;
+    session.turns.push({ role, text: normalizedText, at: new Date().toISOString() });
+};
 
 const buildTurnDetectionConfig = () => {
     if (VAD_TYPE === 'semantic_vad') {
@@ -234,29 +248,14 @@ fastify.register(async (fastify) => {
                 // ユーザーの音声認識結果を処理
                 if (response.type === 'conversation.item.input_audio_transcription.completed') {
                     const userMessage = response.transcript.trim();
-                    session.transcript += `User: ${userMessage}\n`;
-                    session.turns.push({ role: 'user', text: userMessage, at: new Date().toISOString() });
-                    if (SHOULD_LOG_TRANSCRIPTS) console.log(`User (${sessionId}): ${userMessage}`);
-                }
-
-                // エージェントの応答を処理
-                if (response.type === 'response.done') {
-                    const output = response.response.output || [];
-                    const agentMessage = output
-                        .flatMap(item => item.content || [])
-                        .find(content => content.transcript || content.text)?.transcript;
-                    if (agentMessage) {
-                        session.transcript += `Agent: ${agentMessage}\n`;
-                        session.turns.push({ role: 'agent', text: agentMessage, at: new Date().toISOString() });
-                        if (SHOULD_LOG_TRANSCRIPTS) console.log(`Agent (${sessionId}): ${agentMessage}`);
-                    }
+                    appendTurn(session, 'user', userMessage);
+                    if (SHOULD_LOG_TRANSCRIPTS && userMessage) console.log(`User (${sessionId}): ${userMessage}`);
                 }
 
                 if (response.type === 'response.output_audio_transcript.done') {
-                    const agentMessage = response.transcript || 'Agent message not found';
-                    session.transcript += `Agent: ${agentMessage}\n`;
-                    session.turns.push({ role: 'agent', text: agentMessage, at: new Date().toISOString() });
-                    if (SHOULD_LOG_TRANSCRIPTS) console.log(`Agent (${sessionId}): ${agentMessage}`);
+                    const agentMessage = response.transcript || '';
+                    appendTurn(session, 'agent', agentMessage);
+                    if (SHOULD_LOG_TRANSCRIPTS && agentMessage) console.log(`Agent (${sessionId}): ${agentMessage}`);
                 }
 
                 if (response.type === 'session.updated') {
@@ -367,7 +366,12 @@ async function extractCallDetails(transcript) {
                 input: [
                     {
                         role: 'system',
-                        content: 'あなたは日本のコールセンター通話ログを構造化するオペレーターです。事実だけを抽出し、不明な項目は空文字またはfalseにしてください。'
+                        content: [
+                            'あなたは日本のコールセンター通話ログを構造化するオペレーターです。',
+                            '事実だけを抽出し、不明な項目は空文字またはfalseにしてください。',
+                            '顧客名は、通話中で最後に本人が訂正または確認した読みを優先してください。',
+                            '顧客名は推測で一般的な漢字へ変換せず、文字起こしにカタカナやひらがながある場合はその表記を優先してください。'
+                        ].join('\n')
                     },
                     {
                         role: 'user',

--- a/lib/call-log-sinks.js
+++ b/lib/call-log-sinks.js
@@ -26,11 +26,33 @@ const toIsoString = (value) => {
     return new Date(value).toISOString();
 };
 
+const toJstString = (value) => {
+    if (!value) return '';
+    const date = value instanceof Date ? value : new Date(value);
+    const parts = new Intl.DateTimeFormat('ja-JP', {
+        timeZone: 'Asia/Tokyo',
+        year: 'numeric',
+        month: '2-digit',
+        day: '2-digit',
+        hour: '2-digit',
+        minute: '2-digit',
+        second: '2-digit',
+        hour12: false
+    }).formatToParts(date);
+    const get = (type) => parts.find(part => part.type === type)?.value || '';
+    return `${get('year')}-${get('month')}-${get('day')} ${get('hour')}:${get('minute')}:${get('second')}`;
+};
+
 const sanitizeSheetValue = (value) => {
     if (value === null || value === undefined) return '';
     if (Array.isArray(value)) return value.join(', ');
     if (typeof value === 'object') return JSON.stringify(value);
     return String(value);
+};
+
+const asSheetText = (value) => {
+    const text = sanitizeSheetValue(value);
+    return text ? `'${text}` : '';
 };
 
 export function buildCallLogRecord(session, extraction = null) {
@@ -46,6 +68,8 @@ export function buildCallLogRecord(session, extraction = null) {
         to: session.to || '',
         startedAt: toIsoString(startedAt),
         endedAt: toIsoString(endedAt),
+        startedAtJst: toJstString(startedAt),
+        endedAtJst: toJstString(endedAt),
         durationSeconds,
         status: session.status || 'completed',
         disconnectReason: session.disconnectReason || '',
@@ -209,16 +233,16 @@ export class CallLogSinks {
     toSheetRow(record) {
         return [
             record.callSid,
-            record.startedAt,
-            record.endedAt,
+            record.startedAtJst || record.startedAt,
+            record.endedAtJst || record.endedAt,
             record.durationSeconds,
-            record.from,
-            record.to,
+            asSheetText(record.from),
+            asSheetText(record.to),
             record.intent,
             record.summary,
             record.callbackRequired ? '要' : '不要',
             record.customerName,
-            record.customerPhoneNumber,
+            asSheetText(record.customerPhoneNumber),
             record.preferredDatetime,
             record.status,
             record.disconnectReason || record.openAiError,


### PR DESCRIPTION
## 概要
- Google Sheetsの開始/終了時刻をUTC ISOではなく日本時間のYYYY-MM-DD HH:mm:ssで出力
- FirestoreにはUTC ISOに加えて startedAtJst / endedAtJst を保存
- 発信者番号、着信番号、顧客電話番号をSheetsで文字列扱いにし、先頭+や0落ちを防止
- エージェント発話の二重記録を解消
- 氏名を勝手に漢字変換せず、読みをカタカナで確認するようプロンプトを改善
- 抽出時も最後に本人が訂正・確認した読みを優先

## 検証
- npm test
- npm run check:realtime
- npm run smoke:local
- npm run smoke:media-stream
- 名前抽出プロンプト単体確認: テリスケをテリスケとして抽出
- Cloud Run手動デプロイ: speech-assistant-realtime-00008-5rr
- Cloud Run WebSocket smoke成功
- Firestoreに startedAtJst / endedAtJst 保存を確認
- Google Sheets追記成功ログを確認

## 補足
既存の過去行はそのままです。新規追記行からJST表示と重複排除が適用されます。