### PR TITLE
Show admin phone fields and cleanup test logs

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -103,7 +103,9 @@ ADMIN_BASIC_USER=admin ADMIN_BASIC_PASSWORD=change-me npm run start
 
 起動後、`http://localhost:5050/app/` にアクセスします。認証情報は `.env` または環境変数で設定してください。
 
-管理UIの「対応内容を保存」はFirestore `callLogs` の各通話ドキュメントに `ops` として保存します。対応ステータスを `完了` にした通話は、一覧の `完了` フィルタで確認できます。
+管理UIの「対応内容を保存」はFirestore `callLogs` の各通話ドキュメントに `ops` として保存します。対応ステータスを `完了` にした通話は、一覧の `完了` フィルタで確認できます。管理UI/APIはBasic認証済み管理者だけが見る前提のため、発信者番号・着信番号・顧客電話番号はマスクせず表示します。
+
+`検証ログ削除` は、`CA_SMOKE` で始まる疎通確認ログと、文字起こし・turns・要約・用件がすべて空のログだけを削除します。
 
 管理UIのRealtimeモデル選択はFirestore `runtimeSettings/admin` に保存され、次回以降の新しい通話から `gpt-realtime-1.5` / `gpt-realtime-2` の選択が反映されます。進行中の通話には反映しません。
 

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -22,6 +22,9 @@ type CallLog = {
     disconnectReasonLabel?: string;
     disconnectReasonCategory?: string;
     openAiError?: string;
+    from?: string;
+    to?: string;
+    customerPhoneNumber?: string;
     fromDisplay?: string;
     toDisplay?: string;
     customerPhoneDisplay?: string;
@@ -238,9 +241,11 @@ function App() {
     const [detailStatus, setDetailStatus] = useState<LoadState>('idle');
     const [saveStatus, setSaveStatus] = useState<LoadState>('idle');
     const [settingsSaveStatus, setSettingsSaveStatus] = useState<LoadState>('idle');
+    const [cleanupStatus, setCleanupStatus] = useState<LoadState>('idle');
     const [error, setError] = useState('');
     const [saveError, setSaveError] = useState('');
     const [settingsError, setSettingsError] = useState('');
+    const [cleanupMessage, setCleanupMessage] = useState('');
     const [filter, setFilter] = useState<Filter>('all');
     const [runtimeDraft, setRuntimeDraft] = useState({
         realtimeModel: 'gpt-realtime-2',
@@ -429,6 +434,26 @@ function App() {
         }
     };
 
+    const cleanupTestLogs = async () => {
+        if (!window.confirm('CA_SMOKEで始まる検証ログと、会話内容が空のログを削除します。よろしいですか。')) {
+            return;
+        }
+
+        setCleanupStatus('loading');
+        setCleanupMessage('');
+        try {
+            const result = await fetchJson<{ deleted: number }>('/api/admin/call-logs/test-or-empty?limit=500', {
+                method: 'DELETE'
+            });
+            setCleanupMessage(`${result.deleted}件の検証/空ログを削除しました`);
+            setCleanupStatus('ready');
+            await loadDashboard();
+        } catch (cleanupErrorValue) {
+            setCleanupMessage(cleanupErrorValue instanceof Error ? cleanupErrorValue.message : '検証ログ削除に失敗しました');
+            setCleanupStatus('error');
+        }
+    };
+
     return (
         <main className="min-h-dvh bg-slate-50 px-4 py-6 text-slate-900 sm:px-6 lg:px-8" aria-busy={isDashboardLoading}>
             <div className="mx-auto grid w-full min-w-0 max-w-7xl gap-6">
@@ -437,19 +462,42 @@ function App() {
                         <p className="text-sm font-medium text-slate-500">Cor Voice Admin</p>
                         <h1 className="text-balance text-2xl font-semibold text-slate-950">通話ログ管理</h1>
                     </div>
-                    <button
-                        type="button"
-                        onClick={loadDashboard}
-                        className="w-fit rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400 disabled:opacity-60"
-                        disabled={isDashboardLoading}
-                    >
-                        {isDashboardLoading ? '読み込み中' : '再読み込み'}
-                    </button>
+                    <div className="flex flex-wrap gap-2">
+                        <button
+                            type="button"
+                            onClick={cleanupTestLogs}
+                            className="w-fit rounded border border-red-200 bg-white px-4 py-2 text-sm font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-200 disabled:opacity-60"
+                            disabled={cleanupStatus === 'loading'}
+                        >
+                            {cleanupStatus === 'loading' ? '削除中' : '検証ログ削除'}
+                        </button>
+                        <button
+                            type="button"
+                            onClick={loadDashboard}
+                            className="w-fit rounded border border-slate-300 bg-white px-4 py-2 text-sm font-medium hover:bg-slate-100 focus:outline-none focus:ring-2 focus:ring-slate-400 disabled:opacity-60"
+                            disabled={isDashboardLoading}
+                        >
+                            {isDashboardLoading ? '読み込み中' : '再読み込み'}
+                        </button>
+                    </div>
                 </header>
 
                 {error && (
                     <div className="rounded border border-red-200 bg-red-50 p-4 text-sm text-red-800" role="alert">
                         {error}
+                    </div>
+                )}
+                {cleanupMessage && (
+                    <div
+                        className={cn(
+                            'rounded border p-4 text-sm',
+                            cleanupStatus === 'error'
+                                ? 'border-red-200 bg-red-50 text-red-800'
+                                : 'border-emerald-200 bg-emerald-50 text-emerald-800'
+                        )}
+                        role={cleanupStatus === 'error' ? 'alert' : 'status'}
+                    >
+                        {cleanupMessage}
                     </div>
                 )}
 
@@ -503,7 +551,8 @@ function App() {
                             <div className="overflow-hidden rounded border border-slate-200 bg-white">
                                 <div className="divide-y divide-slate-100">
                                     {filteredLogs.map((log) => {
-                                        const phoneDisplay = log.customerPhoneDisplay || log.fromDisplay || '-';
+                                        const fromPhone = log.from || log.fromDisplay || '-';
+                                        const toPhone = log.to || log.toDisplay || '-';
 
                                         return (
                                             <button
@@ -530,7 +579,8 @@ function App() {
                                                 <div className="flex flex-wrap gap-x-4 gap-y-1 text-xs text-slate-500">
                                                     <span className="tabular-nums">{formatDate(log.startedAt)}</span>
                                                     <span className="tabular-nums">{formatDuration(log.durationSeconds || 0)}</span>
-                                                    <span className="tabular-nums">発信 {phoneDisplay}</span>
+                                                    <span className="tabular-nums">発信 {fromPhone}</span>
+                                                    <span className="tabular-nums">着信 {toPhone}</span>
                                                 </div>
                                             </button>
                                         );
@@ -557,11 +607,15 @@ function App() {
                                     <dl className="grid grid-cols-2 gap-3 text-sm">
                                         <div className="min-w-0">
                                             <dt className="text-slate-500">発信者</dt>
-                                            <dd className="break-words font-medium">{selectedLog.fromDisplay || '-'}</dd>
+                                            <dd className="break-words font-medium">{selectedLog.from || selectedLog.fromDisplay || '-'}</dd>
+                                        </div>
+                                        <div className="min-w-0">
+                                            <dt className="text-slate-500">着信番号</dt>
+                                            <dd className="break-words font-medium">{selectedLog.to || selectedLog.toDisplay || '-'}</dd>
                                         </div>
                                         <div className="min-w-0">
                                             <dt className="text-slate-500">顧客電話</dt>
-                                            <dd className="break-words font-medium">{selectedLog.customerPhoneDisplay || '-'}</dd>
+                                            <dd className="break-words font-medium">{selectedLog.customerPhoneNumber || selectedLog.customerPhoneDisplay || '-'}</dd>
                                         </div>
                                         <div className="min-w-0">
                                             <dt className="text-slate-500">希望日時</dt>

--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -65,6 +65,8 @@ https://<cloud-run-url>/incoming-call
 
 対応ステータス、折り返し状況、担当者、メモはFirestore `callLogs` の対象通話ドキュメントに `ops` として保存します。RealtimeモデルのUI選択はFirestore `runtimeSettings/admin` に保存し、次回以降の新規通話で利用します。Cloud Runのローカルファイルシステム上のSQLiteはインスタンス・revisionを跨ぐ永続DBとして扱わず、Cloud Run運用ではFirestoreを正とします。
 
+管理UI/APIはBasic認証済み管理者だけが見る前提のため、発信者番号・着信番号・顧客電話番号はマスクせず表示します。`検証ログ削除` は `CA_SMOKE` で始まる疎通確認ログと、会話内容が空のログだけを削除します。
+
 ## 通話ログ
 
 通話ログは既存Firebaseのdefault databaseではなく、専用Firestore named database `your-firestore-database-id` の `callLogs` に保存します。Google Sheets `your-spreadsheet-id` は運用ビューとして通話終了時に1行追記します。

--- a/lib/admin-routes.js
+++ b/lib/admin-routes.js
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import { CallLogStore } from './call-log-store.js';
 import { describeDisconnectReason } from './disconnect-reasons.js';
 import { RuntimeSettingsStore } from './runtime-settings-store.js';
-import { auditLog as defaultAuditLog, maskPhone } from './security.js';
+import { auditLog as defaultAuditLog } from './security.js';
 import { getRuntimeConfig, sanitizeRuntimeConfig } from './runtime-config.js';
 import { validateRealtimeSettingsPatch } from './realtime-models.js';
 
@@ -11,8 +11,6 @@ const ADMIN_REALM = 'Cor Voice Admin';
 const isPlainObject = (value) => Boolean(value)
     && typeof value === 'object'
     && !Array.isArray(value);
-
-const JAPAN_PHONE_TEXT_PATTERN = /(^|[^\d])((?:\+81|0)[\d\s().-]{8,}\d)(?!\d)/g;
 
 const hash = (value) => crypto
     .createHash('sha256')
@@ -114,11 +112,17 @@ const requireAdmin = (auth, auditLog) => async (request, reply) => {
         .send({ error: 'unauthorized' });
 };
 
-const phoneDisplays = (record) => ({
-    fromDisplay: maskPhone(record.from),
-    toDisplay: maskPhone(record.to),
-    customerPhoneDisplay: maskPhone(record.customerPhoneNumber || record.extraction?.customerPhoneNumber)
-});
+const visiblePhoneFields = ({ from, to, customerPhoneNumber, extraction }) => {
+    const customerPhone = customerPhoneNumber || extraction?.customerPhoneNumber || '';
+    return {
+        from,
+        to,
+        customerPhoneNumber: customerPhone,
+        fromDisplay: from,
+        toDisplay: to,
+        customerPhoneDisplay: customerPhone
+    };
+};
 
 const getOps = (log) => isPlainObject(log.ops) ? log.ops : {};
 
@@ -129,34 +133,19 @@ const isInProgress = (log) => ['needs_callback', 'in_progress'].includes(getOps(
 
 const isCompleted = (log) => getOps(log).status === 'done';
 
-const redactPhoneText = (value) => {
-    if (typeof value !== 'string') return value;
-    return value.replace(JAPAN_PHONE_TEXT_PATTERN, (_match, prefix, phone) => `${prefix}${maskPhone(phone)}`);
-};
-
-const redactPhoneValues = (value) => {
-    if (Array.isArray(value)) return value.map(redactPhoneValues);
+const copyPlainValues = (value) => {
+    if (Array.isArray(value)) return value.map(copyPlainValues);
     if (isPlainObject(value)) {
         return Object.fromEntries(
-            Object.entries(value).map(([key, entry]) => [key, redactPhoneValues(entry)])
+            Object.entries(value).map(([key, entry]) => [key, copyPlainValues(entry)])
         );
     }
-    return redactPhoneText(value);
+    return value;
 };
 
-const sanitizeExtraction = (extraction) => {
+const visibleExtraction = (extraction) => {
     if (!isPlainObject(extraction)) return extraction || null;
-    const {
-        customerPhoneNumber,
-        customerPhoneDisplay,
-        ...safeExtraction
-    } = extraction;
-    return {
-        ...redactPhoneValues(safeExtraction),
-        customerPhoneDisplay: customerPhoneNumber
-            ? maskPhone(customerPhoneNumber)
-            : redactPhoneText(customerPhoneDisplay || '')
-    };
+    return copyPlainValues(extraction);
 };
 
 const sanitizeCallLog = (record, { includeTranscript = false } = {}) => {
@@ -185,26 +174,26 @@ const sanitizeCallLog = (record, { includeTranscript = false } = {}) => {
         endedAtJst: source.endedAtJst || '',
         durationSeconds: source.durationSeconds || 0,
         status: source.status || '',
-        disconnectReason: redactPhoneText(source.disconnectReason || ''),
-        disconnectReasonLabel: redactPhoneText(disconnect.label || ''),
+        disconnectReason: source.disconnectReason || '',
+        disconnectReasonLabel: disconnect.label || '',
         disconnectReasonCategory: disconnect.category || 'unknown',
         openAiCloseCode: source.openAiCloseCode || '',
-        openAiError: redactPhoneText(source.openAiError || ''),
-        summary: redactPhoneText(source.summary || ''),
-        intent: redactPhoneText(source.intent || ''),
+        openAiError: source.openAiError || '',
+        summary: source.summary || '',
+        intent: source.intent || '',
         callbackRequired: Boolean(source.callbackRequired),
-        customerName: redactPhoneText(source.customerName || ''),
-        preferredDatetime: redactPhoneText(source.preferredDatetime || ''),
+        customerName: source.customerName || '',
+        preferredDatetime: source.preferredDatetime || '',
         createdAt: source.createdAt || '',
         updatedAt: source.updatedAt || '',
-        ops: redactPhoneValues(isPlainObject(source.ops) ? source.ops : {}),
+        ops: copyPlainValues(isPlainObject(source.ops) ? source.ops : {}),
         opsUpdatedAt: source.opsUpdatedAt || '',
         opsUpdatedBy: source.opsUpdatedBy || '',
-        ...phoneDisplays({ from, to, customerPhoneNumber, extraction }),
-        extraction: sanitizeExtraction(extraction),
+        ...visiblePhoneFields({ from, to, customerPhoneNumber, extraction }),
+        extraction: visibleExtraction(extraction),
         ...(includeTranscript ? {
-            transcript: redactPhoneText(transcript),
-            turns: redactPhoneValues(turns)
+            transcript,
+            turns: copyPlainValues(turns)
         } : {})
     };
 };
@@ -307,6 +296,36 @@ export async function registerAdminRoutes(fastify, {
         } catch (error) {
             return handleStoreError(reply, error);
         }
+    });
+
+    fastify.delete('/api/admin/call-logs/test-or-empty', { preHandler }, async (request, reply) => {
+        if (typeof store.deleteTestOrEmptyLogs !== 'function') {
+            reply.code(501);
+            return {
+                error: 'unsupported_store',
+                message: 'Call log cleanup is not supported by this store'
+            };
+        }
+
+        let result;
+        try {
+            result = await store.deleteTestOrEmptyLogs({
+                limit: request.query?.limit
+            });
+        } catch (error) {
+            return handleStoreError(reply, error);
+        }
+
+        auditLog('admin.call_log.cleanup_test_or_empty', {
+            actor: request.adminAuth?.actor || 'admin',
+            target: 'callLogs',
+            metadata: {
+                deleted: result.deleted,
+                ids: result.items.map((item) => item.id)
+            }
+        });
+
+        return result;
     });
 
     fastify.get('/api/admin/call-logs/:callSid', { preHandler }, async (request, reply) => {
@@ -420,7 +439,7 @@ export async function registerAdminRoutes(fastify, {
                 policy: {
                     listResponsesIncludeTranscript: false,
                     detailResponsesRequireAdminAuth: true,
-                    phoneNumbersAreMaskedInAdminResponses: true,
+                    phoneNumbersAreVisibleInAdminResponses: true,
                     opsResponsesPersistToFirestore: true,
                     runtimeModelSelectionPersistsToFirestore: true
                 }

--- a/lib/call-log-store.js
+++ b/lib/call-log-store.js
@@ -28,6 +28,17 @@ const isInProgress = (log) => ['needs_callback', 'in_progress'].includes(getOps(
 
 const isCompleted = (log) => getOps(log).status === 'done';
 
+const isTestOrEmptyLog = (record) => {
+    const callSid = String(record.callSid || '').trim();
+    const turns = Array.isArray(record.turns) ? record.turns : [];
+    const noConversation = !String(record.transcript || '').trim()
+        && turns.length === 0
+        && !String(record.summary || '').trim()
+        && !String(record.intent || '').trim();
+
+    return callSid.startsWith('CA_SMOKE') || noConversation;
+};
+
 export class CallLogStoreUnavailableError extends Error {
     constructor(operation, cause) {
         super('Call log storage is unavailable', { cause });
@@ -138,6 +149,56 @@ export class CallLogStore {
             completed: logs.filter(isCompleted).length,
             needsReview: logs.filter((log) => Boolean(getOps(log).needsReview)).length
         };
+    }
+
+    async deleteTestOrEmptyLogs({ limit = 200 } = {}) {
+        if (!this.firestoreEnabled) return { deleted: 0, items: [] };
+
+        try {
+            const collection = this.getCollection();
+            const snapshot = await collection
+                .orderBy('startedAt', 'desc')
+                .limit(Math.min(Math.max(Number(limit) || 200, 1), 500))
+                .get();
+
+            const targets = snapshot.docs
+                .map((doc) => ({
+                    ref: doc.ref,
+                    id: doc.id,
+                    data: {
+                        callSid: doc.id,
+                        ...firestoreValueToJson(doc.data())
+                    }
+                }))
+                .filter(({ data }) => isTestOrEmptyLog(data));
+
+            if (targets.length === 0) return { deleted: 0, items: [] };
+
+            let batch = this.getFirestore().batch();
+            let pending = 0;
+            for (const target of targets) {
+                batch.delete(target.ref);
+                pending += 1;
+                if (pending === 450) {
+                    await batch.commit();
+                    batch = this.getFirestore().batch();
+                    pending = 0;
+                }
+            }
+            if (pending > 0) await batch.commit();
+
+            return {
+                deleted: targets.length,
+                items: targets.map(({ id, data }) => ({
+                    id,
+                    callSid: data.callSid || id,
+                    startedAt: data.startedAt || '',
+                    reason: String(data.callSid || id).startsWith('CA_SMOKE') ? 'smoke_test' : 'empty_conversation'
+                }))
+            };
+        } catch (error) {
+            throwStoreUnavailable('delete-test-logs', error);
+        }
     }
 
     health() {

--- a/test/admin-routes.test.js
+++ b/test/admin-routes.test.js
@@ -35,6 +35,22 @@ class FakeStore {
         this.records.set(callSid, record);
         return structuredClone(record);
     }
+
+    async deleteTestOrEmptyLogs() {
+        const items = [];
+        for (const [callSid, record] of this.records.entries()) {
+            const turns = Array.isArray(record.turns) ? record.turns : [];
+            const isEmpty = !String(record.transcript || '').trim()
+                && turns.length === 0
+                && !String(record.summary || '').trim()
+                && !String(record.intent || '').trim();
+            if (callSid.startsWith('CA_SMOKE') || isEmpty) {
+                this.records.delete(callSid);
+                items.push({ id: callSid, callSid });
+            }
+        }
+        return { deleted: items.length, items };
+    }
 }
 
 class FakeSettingsStore {
@@ -221,7 +237,7 @@ test('admin routes handle Basic Auth credentials strictly', async () => {
     assert.equal(lowercaseScheme.statusCode, 200);
 });
 
-test('call log list masks phone fields and PII text while omitting transcript bodies', async () => {
+test('call log list exposes admin phone fields while omitting transcript bodies', async () => {
     const app = await buildApp();
 
     const response = await app.inject({
@@ -233,28 +249,27 @@ test('call log list masks phone fields and PII text while omitting transcript bo
     assert.equal(response.statusCode, 200);
     const body = response.json();
     assert.equal(body.count, 1);
-    assert.equal(body.items[0].fromDisplay, '+****5678');
-    assert.equal(body.items[0].toDisplay, '+****2222');
-    assert.equal(body.items[0].customerPhoneDisplay, '****8888');
-    assert.equal(body.items[0].summary, '予約相談 ****5678');
-    assert.equal(body.items[0].from, undefined);
-    assert.equal(body.items[0].to, undefined);
-    assert.equal(body.items[0].customerPhoneNumber, undefined);
+    assert.equal(body.items[0].from, '+819012345678');
+    assert.equal(body.items[0].to, '+81311112222');
+    assert.equal(body.items[0].customerPhoneNumber, '09099998888');
+    assert.equal(body.items[0].fromDisplay, '+819012345678');
+    assert.equal(body.items[0].toDisplay, '+81311112222');
+    assert.equal(body.items[0].customerPhoneDisplay, '09099998888');
+    assert.equal(body.items[0].summary, '予約相談 090-1234-5678');
     assert.equal(body.items[0].accountSid, undefined);
     assert.equal(body.items[0].streamSid, undefined);
     assert.equal(body.items[0].internalOperatorNote, undefined);
     assert.equal(body.items[0].transcript, undefined);
     assert.equal(body.items[0].turns, undefined);
-    assert.equal(body.items[0].extraction.customerPhoneNumber, undefined);
-    assert.equal(body.items[0].extraction.customerPhoneDisplay, '****2222');
-    assert.equal(body.items[0].extraction.summary, '予約相談 ****5678');
-    assert.equal(body.items[0].extraction.alternatePhoneNumber, '****3333');
+    assert.equal(body.items[0].extraction.customerPhoneNumber, '08011112222');
+    assert.equal(body.items[0].extraction.summary, '予約相談 090-1234-5678');
+    assert.equal(body.items[0].extraction.alternatePhoneNumber, '090-2222-3333');
     assert.doesNotMatch(response.body, /raw transcript/);
-    assert.doesNotMatch(response.body, /090-1234-5678/);
-    assert.doesNotMatch(response.body, /090-2222-3333/);
+    assert.match(response.body, /090-1234-5678/);
+    assert.match(response.body, /090-2222-3333/);
 });
 
-test('call log detail is protected and redacts phone PII in transcript text', async () => {
+test('call log detail is protected and exposes full admin phone fields', async () => {
     const app = await buildApp();
 
     const response = await app.inject({
@@ -266,20 +281,21 @@ test('call log detail is protected and redacts phone PII in transcript text', as
     assert.equal(response.statusCode, 200);
     const body = response.json();
     assert.equal(body.callSid, 'call-1');
+    assert.equal(body.from, '+819012345678');
+    assert.equal(body.to, '+81311112222');
+    assert.equal(body.customerPhoneNumber, '09099998888');
     assert.equal(body.isSmokeTest, false);
-    assert.match(body.transcript, /Phone \*\*\*\*5678 and \+\*\*\*\*2222/);
-    assert.equal(body.turns[0].text, 'hello from ****2222');
-    assert.equal(body.from, undefined);
-    assert.equal(body.to, undefined);
+    assert.match(body.transcript, /Phone 090-1234-5678 and \+819011112222/);
+    assert.equal(body.turns[0].text, 'hello from 080-1111-2222');
     assert.equal(body.accountSid, undefined);
     assert.equal(body.streamSid, undefined);
     assert.equal(body.internalOperatorNote, undefined);
-    assert.equal(body.fromDisplay, '+****5678');
-    assert.equal(body.customerPhoneDisplay, '****8888');
+    assert.equal(body.fromDisplay, '+819012345678');
+    assert.equal(body.customerPhoneDisplay, '09099998888');
     assert.equal(body.disconnectReasonLabel, 'Twilio Media Streamsが理由コードなしで切断しました');
-    assert.doesNotMatch(response.body, /090-1234-5678/);
-    assert.doesNotMatch(response.body, /\+819011112222/);
-    assert.doesNotMatch(response.body, /080-1111-2222/);
+    assert.match(response.body, /090-1234-5678/);
+    assert.match(response.body, /\+819011112222/);
+    assert.match(response.body, /080-1111-2222/);
 });
 
 test('ops patch only merges ops metadata and audits the update', async () => {
@@ -310,9 +326,9 @@ test('ops patch only merges ops metadata and audits the update', async () => {
     assert.equal(response.statusCode, 200);
     const body = response.json();
     assert.equal(body.ops.status, 'needs_callback');
-    assert.equal(body.ops.memo, 'call ****5555 tomorrow');
-    assert.match(body.transcript, /Phone \*\*\*\*5678/);
-    assert.equal(body.summary, '予約相談 ****5678');
+    assert.equal(body.ops.memo, 'call 090-4444-5555 tomorrow');
+    assert.match(body.transcript, /Phone 090-1234-5678/);
+    assert.equal(body.summary, '予約相談 090-1234-5678');
 
     const stored = await store.get('call-1');
     assert.equal(stored.transcript, sampleRecord.transcript);
@@ -322,6 +338,39 @@ test('ops patch only merges ops metadata and audits the update', async () => {
     assert.equal(auditEvents.length, 1);
     assert.equal(auditEvents[0].action, 'admin.call_log.ops_update');
     assert.deepEqual(auditEvents[0].details.metadata.keys, ['status', 'memo']);
+});
+
+test('test and empty call log cleanup deletes only safe candidates', async () => {
+    const store = new FakeStore([
+        sampleRecord,
+        {
+            callSid: 'CA_SMOKE_1',
+            transcript: '',
+            turns: [],
+            summary: '',
+            intent: ''
+        },
+        {
+            callSid: 'CA_EMPTY_1',
+            transcript: '',
+            turns: [],
+            summary: '',
+            intent: ''
+        }
+    ]);
+    const app = await buildApp({ store });
+
+    const response = await app.inject({
+        method: 'DELETE',
+        url: '/api/admin/call-logs/test-or-empty',
+        headers: authHeader()
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.json().deleted, 2);
+    assert.equal(await store.get('call-1') !== null, true);
+    assert.equal(await store.get('CA_SMOKE_1'), null);
+    assert.equal(await store.get('CA_EMPTY_1'), null);
 });
 
 test('empty Firestore collection returns an empty admin API payload', async () => {


### PR DESCRIPTION
## Summary
- Treat the Basic-auth admin UI/API as an operator-only surface and expose full caller/callee/customer phone numbers.
- Show both 発信 and 着信 numbers in the call list, and add 着信番号 to detail view.
- Keep transcripts out of list responses, but expose full phone details in authenticated detail responses.
- Add a Basic-auth protected cleanup endpoint/button for `CA_SMOKE` and empty-conversation logs.
- Document Firestore persistence and cleanup behavior.

## Verification
- `npm test`
- `npm audit`
- `git diff --check`
- Local smoke: `SMOKE_BASE_URL=http://127.0.0.1:5059 npm run smoke:local`
- Local admin cleanup endpoint: returns `{ deleted: 0, items: [] }` when Firestore is disabled.
