### PR TITLE
docs: record Cor Cloud Run preview URL

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,8 @@
 
 Cor.管理の検証用デプロイは [Cloud Run UI](https://speech-assistant-realtime-mggisi6odq-an.a.run.app/app/) で確認できます。`/app` と `/api/admin/*` はHTTP Basic認証で保護され、通話一覧・抽出結果・ランタイム設定・ログ保存ポリシーを確認するための汎用管理UIとして実装しています。
 
+正確なCloud Run URL、Twilio webhook、Media Streams WebSocket、管理API URLは [docs/cor-cloud-run-preview.md](./docs/cor-cloud-run-preview.md) に記録しています。
+
 このURLはCor.側の検証環境です。顧客・提携先へ引き渡すリポジトリや資料では、実URLではなく `https://<cloud-run-host>/app/` のようなプレースホルダーに置き換えてください。
 
 このアプリケーションは、Node.js、[Twilio Voice](https://www.twilio.com/docs/voice)と[Media Streams](https://www.twilio.com/docs/voice/media-streams)、[OpenAIのRealtime API](https://platform.openai.com/docs/)を使用して、AIアシスタントとの電話会話を可能にする方法を示しています。 

--- a/docs/cloud-run-deployment.md
+++ b/docs/cloud-run-deployment.md
@@ -4,6 +4,8 @@
 
 ローカル検証済みのNode/Fastify + Twilio Media Streams + OpenAI Realtime構成を、Google Cloud Run上で常時起動できる最小基盤として動かします。
 
+Cor.株式会社の現在の検証用Cloud Run URLは [cor-cloud-run-preview.md](./cor-cloud-run-preview.md) を参照してください。
+
 ## 前提
 
 - GCP project: `your-gcp-project-id`

--- a/docs/cor-cloud-run-preview.md
+++ b/docs/cor-cloud-run-preview.md
@@ -1,0 +1,45 @@
+# Cor. Cloud Run Preview URL
+
+## Current Deployment
+
+This repository is deployed by Cor.株式会社 to the following Google Cloud Run service.
+
+| Item | Value |
+| --- | --- |
+| GCP project ID | `aipartner-426616` |
+| GCP project name | `AIPartner` |
+| Region | `asia-northeast1` |
+| Cloud Run service | `speech-assistant-realtime` |
+| Latest verified revision | `speech-assistant-realtime-00021-cfk` |
+| Service URL | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app` |
+
+## Exact URLs
+
+| Purpose | URL |
+| --- | --- |
+| Admin UI | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/app/` |
+| Health check | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/health` |
+| Twilio Voice webhook | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/incoming-call` |
+| Twilio Media Streams WebSocket | `wss://speech-assistant-realtime-mggisi6odq-an.a.run.app/media-stream` |
+| Admin API health | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/api/admin/health` |
+| Admin runtime config | `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/api/admin/runtime-config` |
+
+## Access Notes
+
+- `/app/` and `/api/admin/*` require HTTP Basic Auth.
+- The admin password is intentionally not committed. Manage it via Google Secret Manager `admin-basic-password` and local handoff notes only.
+- This is Cor.株式会社's preview/runtime environment. Delivery repositories and external handoff documents must use placeholders such as `https://<cloud-run-host>/app/`.
+- The repository homepage is set to `https://speech-assistant-realtime-mggisi6odq-an.a.run.app/app/`.
+
+## Verification Commands
+
+```bash
+curl -fsS https://speech-assistant-realtime-mggisi6odq-an.a.run.app/health
+
+curl -fsS -u "$ADMIN_BASIC_USER:$ADMIN_BASIC_PASSWORD" \
+  https://speech-assistant-realtime-mggisi6odq-an.a.run.app/api/admin/health
+
+MEDIA_STREAM_SMOKE_TIMEOUT_MS=30000 \
+SMOKE_WS_URL=wss://speech-assistant-realtime-mggisi6odq-an.a.run.app/media-stream \
+npm run smoke:media-stream
+```


### PR DESCRIPTION
## Summary
- record the exact Cor. Cloud Run UI, health, Twilio webhook, Media Streams, and admin API URLs
- link the URL record from the README and Cloud Run deployment guide
- keep admin credentials out of git and document Secret Manager/local handoff handling

## Validation
- npm test
- npm audit --audit-level=high
- git diff --check