### PR TITLE
docs: AGENTS.mdの開発コマンドと構成説明を実態に合わせる

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,9 @@
 このリポジトリは、Twilio Voice / Media Streams と OpenAI Realtime API をつなぐ日本向け音声AI受付システムです。現時点の本体は `index.js` です。
 
 - `index.js`: Fastifyサーバー、Twilio webhook、Media Streams WebSocket、OpenAI Realtime接続
+- `lib/`: サーバーモジュール（通話ログ、管理APIルート、Realtimeモデル設定、入力ゲート、終話ワークフロー、セキュリティ）
+- `client/`: React管理UI（Vite + Tailwind、`/app/` で配信）
+- `test/`: `node --test` で実行するユニット/軽量結合テスト
 - `scripts/`: ローカル検証用スクリプト
 - `docs/`: ADR、実装計画、検証手順
 - `.env.example`: 環境変数のテンプレート
@@ -15,7 +18,9 @@
 - `npm ci`: lockfileに基づいて依存関係をインストールします。
 - `npm run start`: ローカルサーバーを起動します。
 - `npm run check`: `index.js` の構文チェックを実行します。
-- `npm test`: 現時点では `npm run check` を実行します。
+- `npm run check:frontend`: 管理UI（`client/`）のTypeScript型チェックを実行します。
+- `npm run build:frontend`: 管理UIをViteでビルドします。
+- `npm test`: `npm run check` + `npm run check:frontend` + `npm run build:frontend` を実行した後、`node --test` で `test/` のテストを実行します。
 - `npm run check:realtime`: OpenAI Realtimeへ接続し、GA形式の `session.update` を検証します。
 - `npm run smoke:local`: `/`, `/healthz`, `/incoming-call` を検証します。
 - `npm run smoke:media-stream`: Twilio Media Streams互換のWebSocket検証を行います。


### PR DESCRIPTION
## 概要

AGENTS.md の記述が実装の実態と乖離していたため修正します。2026H2整備（後続のADR/roadmap PR群）の前提となる小さな先行修正です。

## 変更内容

- `npm test` の説明を「`npm run check` のみ」から実態（`check` + `check:frontend` + `build:frontend` + `node --test`）へ更新
- プロジェクト構成に `lib/`（サーバーモジュール）、`client/`（React管理UI）、`test/`（node --test）を追記

## 検証

- `npm ci && npm test` 通過（37 tests / 37 pass / 0 fail）

🤖 Generated with [Claude Code](https://claude.com/claude-code)