### PR TITLE
docs: 人間引き継ぎ第一弾と通知統合の設計を追加する

### DIFF
--- a/docs/handoff-phase1-pstn-transfer.md
+++ b/docs/handoff-phase1-pstn-transfer.md
@@ -1,0 +1,84 @@
+# 人間引き継ぎ第一弾 設計: 携帯PSTN転送 + Whisper
+
+対応ADR: [ADR-0006](./adr/0006-handoff-phase1-pstn-transfer.md) ／ 対応Wave: C1（転送）、C2（Whisper）、C3（不応答フォールバック）
+
+## ゴール
+
+AIが対応困難と判断した通話を、担当者の携帯電話へ転送する。担当者は文脈（AI要約）を聞いてから応答でき、誰も出られない場合は折り返しフローへ確実に落ちる。
+
+## シーケンス
+
+```text
+発信者 ── 050番号 ── AI受付(Realtime)
+                        │ AIがtool `transfer_to_human` を発火（またはユーザーが人間対応を要求）
+                        ▼
+            backend: ライブコールを転送TwiMLへリダイレクト
+            (Twilio REST API POST /Calls/{CallSid} で TwiML差し替え)
+                        │
+                        ▼
+            <Dial callerId="050番号" timeout=20 action="/handoff/dial-status">
+              <Number url="/handoff/whisper" statusCallback="/handoff/leg-status">担当者A</Number>
+              <Number url="/handoff/whisper" ...>担当者B</Number>   ← 最大10番号同時呼、先に出た人に接続
+            </Dial>
+                        │
+          ┌─────────────┴──────────────┐
+          ▼ 担当者が応答                 ▼ 全員不応答/話中 (DialCallStatus != completed)
+   /handoff/whisper:                  /handoff/dial-status:
+   <Say>AIからの引き継ぎです。         <Say>担当者が不在です。折り返しご連絡
+   ○○のご用件、△△様…</Say>           いたします</Say> → callLogsへ折り返し登録
+   <Gather numDigits=1>1で接続</Gather>  → Resendで担当者へメール通知(Wave D1)
+     │ 1押下 → ブリッジ成立              → <Hangup>
+     │ 押下なし/切断 → その番号は不成立
+```
+
+## 新規エンドポイント
+
+| エンドポイント | 役割 | 認証 |
+|---|---|---|
+| `POST /handoff/whisper` | 転送先応答直後に実行されるTwiML（要約`<Say>`+`<Gather>`受諾） | Twilio署名検証 |
+| `POST /handoff/whisper-confirm` | `<Gather>` のaction。1押下でブリッジ継続、その他で`<Hangup>` | Twilio署名検証 |
+| `POST /handoff/dial-status` | `<Dial>` のaction。DialCallStatusで成立/不成立を判定しフォールバック | Twilio署名検証 |
+| `POST /handoff/leg-status` | `<Number>` のstatusCallback。各レッグの監査ログ用 | Twilio署名検証 |
+
+既存の `validateTwilioSignature`（`lib/security.js`）を全エンドポイントに適用する。署名検証はURL完全一致前提のため、各エンドポイントの公開URLを署名検証設定に含めること。
+
+## AI側トリガー（issue #15 対応）
+
+- Realtimeセッションに tool `transfer_to_human` を追加する（既存の `finish_reception` toolフロー＝`lib/realtime-tool-flow.js` のパターンを踏襲）。
+- 発火条件（プロンプトで指示）: 発信者が人間対応を明示要求／AIが2回聞き返しても用件を確定できない／クレーム等の高感情ケース。
+- tool発火時、backendは (1) AIに「担当者へおつなぎします」と発話させ、(2) Twilio REST APIでライブコールを転送TwiMLへリダイレクトし、(3) OpenAI Realtimeセッションを終了する。
+- 要約生成: `session.turns` から Whisper読み上げ用の短い要約（用件・発信者名・折り返し番号）を生成する。既存の抽出（`extractCallDetails`）を同期的に待つとレイテンシが大きいため、転送開始時点のturnsから軽量に生成する方式を実装時に選定する。
+
+## 環境変数（案）
+
+| 変数 | 既定 | 説明 |
+|---|---|---|
+| `HANDOFF_ENABLED` | `false` | 機能フラグ。falseなら tool自体をセッションに追加しない |
+| `HANDOFF_NUMBERS` | （空） | 転送先電話番号のカンマ区切りリスト。**実番号はSecret/環境変数のみで管理し、リポジトリ・docに書かない** |
+| `HANDOFF_DIAL_TIMEOUT_S` | `20` | 呼び出しタイムアウト（秒） |
+| `HANDOFF_WHISPER_ACCEPT_DIGIT` | `1` | 受諾キー |
+| `HANDOFF_CALLER_ID` | （空） | `<Dial callerId>`。通常は自番号（050） |
+
+## 監査ログ
+
+既存の監査ログ形式（actor/action/target/timestamp）で以下を記録する: 転送開始（callSid、転送先は末尾4桁マスク）、whisper受諾/拒否、ブリッジ成立、不応答フォールバック実行。転送先電話番号は本番ログでマスクする（既存 `maskPhone` 方針）。
+
+## コスト目安
+
+日本の携帯への発信は約$0.185/分。転送中は着信+発信の両レッグ課金で概算約29円/分（$1=150円換算、為替は要確認）。固定電話へは約13円/分。
+
+## テスト方針
+
+- `node --test`: TwiML生成（Dial/Number/whisper/Gather）、DialCallStatus分岐、番号マスクのユニットテスト
+- 手動: 実050番号→AI→tool発火→検証用携帯への転送、で通し確認（結果をPR本文へ記録）
+- 反証テスト: `HANDOFF_ENABLED=false` で転送toolがセッションに含まれないこと
+
+## 第二弾（将来）
+
+同時多数着信・モニタリング・ささやき指導が必要になった段階で、[ADR-0002](./adr/0002-operator-console-human-handoff.md) のオペレーターコンソール+Conference構成に進む。Conference型warm transferはTwilio公式参照実装 https://github.com/mhughan-twilio/openai-programmable-sip を採用候補とする。
+
+## 参考
+
+- `<Dial>`/`<Number>`（url属性=whisper、同時呼び出し）: https://www.twilio.com/docs/voice/twiml/number
+- ライブコールのTwiML差し替え: https://www.twilio.com/docs/voice/api/call-resource#update-a-call-resource
+- Twilio日本料金: https://www.twilio.com/en-us/voice/pricing/jp

--- a/docs/notification-resend-outbox.md
+++ b/docs/notification-resend-outbox.md
@@ -1,0 +1,67 @@
+# Resend通知設計: Firestore Outboxによるメール通知
+
+対応ADR: [ADR-0007](./adr/0007-notification-unification-resend.md) ／ 対応Wave: D1
+
+## ゴール
+
+音声問い合わせ（通話）の内容が、テキスト問い合わせ（Cloudia）と同じ宛先へ、同等の信頼性でメール通知される。
+
+## 参照アーキテクチャ: Cloudia（cor-contact-chat）
+
+corsweb2024リポジトリの `workers/contact-chat`（Cloudflare Worker）が既にResend通知を実装している。設計上引き継ぐべき性質:
+
+- **Outboxパターン**: 送信要求を永続化（D1）してからQueue経由で非同期送信。API受付（`accepted`）と配信の区別、`delivery_status`（queued → sending → accepted / failed）管理
+- **fail closed**: `RESEND_API_KEY` 未設定時は503を返し、問い合わせをサイレントに握り潰さない
+- **PII最小化**: Queue payloadにPIIを載せない（IDのみ）
+- 宛先: `cloudia@cor-jp.com`（運用値。環境変数で管理）
+
+D1/QueuesはCloudflare Workerランタイム固有のため流用せず、本システムでは**Firestore**で同型を実装する。
+
+## 本システムでの設計
+
+### Outboxコレクション
+
+Firestore（通話ログと同じDB）に `mailOutbox` コレクションを追加する。
+
+```text
+mailOutbox/{outboxId}:
+  kind: 'call-summary' | 'handoff-fallback'
+  callId: <対応する通話>
+  to / cc / from: 運用値（環境変数から）
+  subject, bodyRef または本文フィールド
+  status: 'queued' | 'sending' | 'accepted' | 'failed'
+  attempts, lastError, providerMessageId
+  createdAt, updatedAt
+```
+
+### 送信ワーカー
+
+Cloud Runの単一サービス構成を維持するため、まずはアプリ内の軽量ワーカー（通話終了時に即時送信を試み、失敗したらoutboxに`queued`で残して定期リトライ）で実装する。Cloud Tasks/Scheduler の導入はスケール要件が出てから検討する（実装issueで判断を記録する）。
+
+### 送信契機
+
+| 契機 | kind | 本文 |
+|---|---|---|
+| 通話終了（正常終話） | `call-summary` | 通話サマリ: 日時、用件（`extractCallDetails` の抽出結果）、折り返し番号、通話時間、管理UIへのリンク |
+| Handoff不応答フォールバック（[handoff-phase1-pstn-transfer.md](./handoff-phase1-pstn-transfer.md) Wave C3） | `handoff-fallback` | 「担当者不応答。折り返しが必要」+ サマリ |
+
+疎通確認通話（`CA_SMOKE` プレフィクス）は送信対象から除外する（既存のsmokeログ除外方針と整合）。
+
+### 環境変数・Secret
+
+| 名前 | 種別 | 説明 |
+|---|---|---|
+| `NOTIFY_EMAIL_ENABLED` | env（既定 `false`） | 機能フラグ |
+| `NOTIFY_EMAIL_TO` / `NOTIFY_EMAIL_CC` / `NOTIFY_EMAIL_FROM` | env | 宛先運用値。Cloudia側と揃える |
+| `resend-api-key` | Secret Manager | Resend APIキー。Cloudia側と同一キー共有か別発行かは実装時にResendダッシュボードで確認して決定 |
+
+### 信頼性・プライバシー
+
+- `RESEND_API_KEY` 未設定かつ `NOTIFY_EMAIL_ENABLED=true` の場合、起動時に警告し、outboxには`failed`を残す（通話自体は止めない。受付システムの「どの部品が落ちても通話は完了する」原則に従う）
+- メール本文には折り返し電話番号等のPIIが含まれる。outboxドキュメントの保持期間を決め、本番ログには本文を出力しない（`maskPhone` 方針維持）
+- Resendの`accepted`はAPI受付を意味し最終配信の保証ではない。配信イベントWebhook連携は将来課題（Cloudia側と同判断）
+
+## テスト方針
+
+- `node --test`: outbox状態遷移、リトライ、fail closed、smoke除外のユニットテスト（Resend APIはフェイク注入）
+- 手動: テスト通話→メール到達確認（結果をPR本文へ記録）


### PR DESCRIPTION
## 概要

ADR-0006/0007（PR #56）の実装設計docを追加します。Wave C1〜C3（携帯転送/Whisper/フォールバック）とWave D1（Resend通知）の実装エージェント向け仕様です。

## 変更内容

- **handoff-phase1-pstn-transfer.md 新規**: 転送シーケンス（tool発火→TwiML差し替え→最大10番号同時呼→Whisper→受諾/フォールバック）、新規エンドポイント4本と署名検証、環境変数案（転送先実番号はSecret/envのみ）、監査ログ、コスト目安、テスト方針、第二弾への言及
- **notification-resend-outbox.md 新規**: Cloudia（cor-contact-chat）を参照アーキテクチャとするFirestore Outbox設計、送信契機（通話サマリ/handoffフォールバック）、fail closed、PII最小化、smoke通話除外

## 検証

- `npm test` 通過（37 tests / 0 fail）
- 電話番号・APIキーの実値は含まれません

🤖 Generated with [Claude Code](https://claude.com/claude-code)