### PR TITLE
docs: DTMFゲートウェイ設計と練習システム引き継ぎ資料を追加する

### DIFF
--- a/docs/dtmf-gateway-design.md
+++ b/docs/dtmf-gateway-design.md
@@ -1,0 +1,60 @@
+# DTMF振り分けゲートウェイ設計
+
+対応ADR: [ADR-0008](./adr/0008-practice-system-separation-dtmf-gateway.md) ／ 対応Wave: E1
+
+## ゴール
+
+1つの050番号で「AI受付（既定）」と「電話応答練習システム（別リポ/別GCPプロジェクト、DTMF `5` で選択）」を振り分ける。**一般の発信者の体験を変えないこと**が最優先。
+
+## 現状と変更点
+
+現在の `/incoming-call` は署名検証後、即座に `<Connect><Stream url="wss://host/media-stream">` を返す（`index.js` の `/incoming-call` ハンドラ）。ここに `<Gather>` による振り分けを**フィーチャーフラグ付き**で挿入する。
+
+### TwiML（フラグON時）
+
+```xml
+<Response>
+  <Gather input="dtmf" numDigits="1" finishOnKey="#" timeout="2"
+          action="/gateway/route" method="POST">
+    <!-- Gather中は無音。一般発信者には案内を流さない（隠しコマンドのため） -->
+  </Gather>
+  <!-- timeout経過（=DTMF入力なし）: 従来のAI受付へ -->
+  <Redirect method="POST">/gateway/route?digits=none</Redirect>
+</Response>
+```
+
+### ルーティング表（`POST /gateway/route`）
+
+| Digits | 遷移先 |
+|---|---|
+| `5` | `<Redirect>` で `PRACTICE_SYSTEM_REDIRECT_URL`（練習システムの `/incoming-call` 相当）へ通話ごと引き渡し |
+| 入力なし（timeout）/ その他 | 従来どおり `<Connect><Stream>`（AI受付） |
+
+- `<Redirect>` はTwilio側で次のTwiML取得先を差し替えるため、**別GCPプロジェクトのCloud Run URLでも動作する**。
+- 練習システム側でも独自にTwilio署名検証を行う（Redirect後のwebhookは練習システム宛のリクエストになる）。
+
+## 設計上の判断
+
+1. **Gatherプロンプトは無音**: `5` は隠しコマンドであり、一般発信者に「練習は5を…」と案内しない。`timeout="2"` 秒の無音は、FIRST_MESSAGE（AI挨拶）開始が2秒遅れることを意味する。実装時に体感を確認し、許容できなければ `timeout="1"` へ短縮を検討する。
+2. **FIRST_MESSAGEとの関係**: 現行はMedia Stream接続後にOpenAI経由で挨拶を発話する。Gatherはその**前段**に挟まるため、Realtimeセッションには影響しない。
+3. **`lib/realtime-input-gate.js` との非干渉**: 入力ゲートの「Xボタン」転写破棄はMedia Stream接続**後**の音声認識に対する処理。Gatherは接続**前**のDTMF収集であり干渉しない。
+4. **署名検証**: `/gateway/route` にも既存の `validateTwilioSignature` を適用する。actionコールバックのURL（クエリ含む）が署名対象になる点に注意。
+5. **フラグOFF時は完全に従来動作**: `DTMF_GATEWAY_ENABLED=false`（既定）なら `<Gather>` を挿入せず、現行TwiMLをそのまま返す。練習システム稼働までOFFを維持する。
+
+## 環境変数
+
+| 変数 | 既定 | 説明 |
+|---|---|---|
+| `DTMF_GATEWAY_ENABLED` | `false` | ゲートウェイ有効化フラグ |
+| `PRACTICE_SYSTEM_REDIRECT_URL` | （空） | 練習システムの着信TwiML URL。空のままフラグONにした場合、`5` 入力でも従来フローへフォールバックする（fail safe） |
+| `DTMF_GATEWAY_TIMEOUT_S` | `2` | Gatherのtimeout秒 |
+
+## テスト方針
+
+- `node --test`: フラグON/OFFのTwiML分岐、digitsルーティング（`5`/none/その他）、URL未設定時のfail safe
+- `npm run smoke:local` / `npm run smoke:media-stream`: フラグOFFで既存動作が非破壊であること（受け入れ条件）
+- 手動: フラグONで実発信し、(a) 何も押さない→AI受付、(b) `5#`→練習システム（未構築の間はテスト用スタブURL）への遷移を確認
+
+## 退役
+
+練習システムが専用番号を持った段階で、フラグOFF→分岐コード削除で退役できる。

--- a/docs/emotion-logic-api-notes.md
+++ b/docs/emotion-logic-api-notes.md
@@ -1,0 +1,91 @@
+# Emotion Logic API 仕様メモ（練習システム引き継ぎ資料）
+
+> **秘匿情報の扱い**: APIキー・パスワードの実値は**いかなるファイル・issue・チャットにも記載しない**。Secret Manager（`emotion-logic-api-key` / `emotion-logic-api-key-password`、練習システム用GCPプロジェクトに配置想定）で管理する。
+>
+> 本docは本リポジトリでは**使用しない**引き継ぎ資料である（[ADR-0008](./adr/0008-practice-system-separation-dtmf-gateway.md): 感情解析は練習システム＝別リポジトリの責務）。新リポジトリ立ち上げ時にコピーする（[practice-system-handover.md](./practice-system-handover.md)）。
+
+## 概要
+
+- **Emotion Logic**: Nemesysco社のLVA（Layered Voice Analysis）技術ベースの音声感情解析プラットフォーム。声の非言語特徴からストレス・感情パラメータを数値化する。
+- **契約経路**: Rabbit Hole Solutions株式会社（RHS）経由。同社の提供名称は「ALICe」。**NDA締結済み、APIキー/パスワード発行済み（2026-04-28、RHS高橋氏からのメール）**。
+- 公式ドキュメント: https://app.emotionlogic.ai/documentation （旧URL emlo.cloud/documentation はリダイレクト）
+- **未確定事項**: 従量単価（RHS高橋氏へ確認する。Wave E2のチェックリスト項目）
+
+## 提供形態（2系統）
+
+| 形態 | エンドポイント | 用途 |
+|---|---|---|
+| ① クラウド直リクエスト | `https://cloud.emlo.cloud/analysis/...` | 通話後ファイル解析（PoC向き） |
+| ② EMLO Docker（セルフホスト） | `http://[docker-ip]/analysis/...` | リアルタイムストリーミング解析＋ファイル解析。音声を自社インフラ内で処理できる |
+
+Docker版のAPIキー/パスワードはインストール時のダッシュボードアクティベーションで使用する。
+
+## ファイル解析API（通話後解析、PoCの本命）
+
+### エンドポイント
+
+- `POST /analysis/analyzeFile` — multipart/form-dataで音声ファイルを直接アップロード（**推奨**: 音声を公開URLに置く必要がない）
+- `POST /analysis/analyzeFromURL` — JSONで音声ファイルのURLを渡す
+
+### 主要パラメータ
+
+| パラメータ | 必須 | 内容 |
+|---|---|---|
+| `file` / `url` | Yes | 解析対象音声 |
+| `sensitivity` | Yes | `normal` / `high` / `low`（falseポジティブとのトレードオフ） |
+| `outputType` | No | `json`（既定） / `text` |
+| `dummyResponse` | No | `true` で**課金なしのダミー応答**（開発用。実装・テストで積極活用する） |
+| `segments` | No | セグメント境界の配列 `[{channel, start, end, text}]`。**文字起こしturns（話者・時刻・本文）をそのまま渡せる**＝練習者発話単位の感情解析が可能 |
+| `requestId` | No | 36文字までの相関ID |
+| `backgroundNoise` | No | 背景ノイズ値（0=自動） |
+
+### クラウド版のみの追加パラメータ
+
+| パラメータ | 必須 | 内容 |
+|---|---|---|
+| `apiKey` / `apiKeyPassword` | Yes | 認証情報（Secret Managerから） |
+| `consentObtainedFromDataSubject` | Yes | **`true` 必須**（被解析者の同意取得をAPIレベルで要求）→ 練習開始前の同意フロー設計と直結 |
+| `useSpeechToText` | No | Emotion Logic側STT（追加課金）。本システムはgpt-4o-transcribeを持つため不要見込み |
+
+## リアルタイム解析（本番のリアルタイム評価向け）
+
+**EMLO Docker（セルフホスト）のみ**で提供。socket.io（WebSocket）ベース。
+
+### イベントフロー
+
+1. クライアント → Docker: `handshake`（音声メタデータ）
+2. Docker → クライアント: `handshake-done`（成功でstreamId）
+3. クライアント → Docker: `audio-stream`（音声バッファを逐次送信）
+4. Docker → クライアント: `audio-analysis`（セグメント解析結果を随時push）
+5. 通話終了時: `fetch-analysis-report` → `analysis-report-ready`（ファイル解析と同形式のレポート）
+
+### handshakeパラメータ
+
+| パラメータ | 必須 | 値 |
+|---|---|---|
+| `isPCM` | Yes | `true` 固定（**PCMのみ対応**） |
+| `channels` | Yes | 1 or 2 |
+| `backgroundNoise` | Yes | 標準 1000 |
+| `bitRate` | Yes | 8 or 16 |
+| `sampleRate` | Yes | **8000対応**（6000/8000/11025/16000/22050/44100/48000） |
+| `outputType` | No | `json`（既定） |
+
+### 電話音声との接続
+
+- Twilio Media Streamsの音声は **G.711 μ-law・8kHz・base64フレーム**。
+- Emotion LogicリアルタイムはPCM必須 → **μ-law→リニアPCM（16bit）変換**が必要。G.711 μ-lawのデコードは256エントリのテーブル参照で、Node.jsで軽量に実装できる。
+- sampleRate 8000が公式サポートされているため、リサンプリングは不要。
+- 評価対象は練習者の声のみ。Twilio Media Streamsの **inboundトラックのみ**をEmotion Logicへ送る（AI顧客役の声を混ぜない）。
+
+## 品質上の注意（要件定義書との整合）
+
+- 電話音声は8kHz狭帯域で高域が欠落する。LVA系解析の精度に上限がかかる可能性があるため、**PoCで実測検証する**（同一発話の電話8kHz vs 広帯域録音の比較、実力群の分離度確認）。
+- 練習者音声の外部送信は個人情報の第三者提供に該当し得る。同意フロー（`consentObtainedFromDataSubject` と整合）とRHSとのDPA整理が必要。Docker版なら音声を自社インフラ内で処理できるため、プライバシー面で有利な選択肢になる。
+
+## 参照
+
+- リクエスト仕様（URL版）: https://app.emotionlogic.ai/documentation/audio-analysis-request-with-url
+- リクエスト仕様（アップロード版）: https://app.emotionlogic.ai/documentation/analysis-request-upload-file
+- リアルタイム解析: https://app.emotionlogic.ai/documentation/realtime-analysis
+- Docker導入: https://app.emotionlogic.ai/documentation/docker_installation
+- レスポンス例: https://app.emotionlogic.ai/documentation/api-response

--- a/docs/practice-system-handover.md
+++ b/docs/practice-system-handover.md
@@ -1,0 +1,72 @@
+# 電話応答練習システム 新リポジトリ立ち上げ引き継ぎ
+
+対応ADR: [ADR-0008](./adr/0008-practice-system-separation-dtmf-gateway.md) ／ 対応Wave: E2
+
+## 位置づけ
+
+アルバイト向け電話応答練習システム（AIが顧客役、練習者の応対を3系統で評価するSaaS構想）は、**本リポジトリをフォークした別リポジトリ + 別GCPプロジェクト**で開発する。企画・要件定義は承認済み（要件定義書 統合版 v1.0、2026-07-10。企画書一式は社内保管）。
+
+本リポジトリとの接点は [DTMFゲートウェイ](./dtmf-gateway-design.md) の `<Redirect>` のみ。
+
+## 立ち上げ手順（チェックリスト）
+
+1. [ ] 本リポジトリをフォークして新リポジトリ（例: `Cor-Incorporated/phone-training-system`）を作成する
+2. [ ] 練習システム用GCPプロジェクトを新設する（受付システムのcor-jp-webとは分離。SaaS課金・テナント分離のため）
+3. [ ] [emotion-logic-api-notes.md](./emotion-logic-api-notes.md) を新リポジトリの `docs/` へコピーする
+4. [ ] Emotion Logicの**従量単価をRHS高橋氏へ確認**し、要件定義書のユニットエコノミクス（1通話原価）を実測値で更新する
+5. [ ] Secret Managerに `emotion-logic-api-key` / `emotion-logic-api-key-password` を登録する（値はRHS発行メール参照。リポジトリに書かない）
+6. [ ] 下記「初期issue一覧」を新リポジトリへ起票する
+7. [ ] 本リポジトリ側のWave E1（DTMFゲートウェイ）と接続し、実発信で `5`+`#` → 練習システム着信を確認する
+
+## 本リポジトリから引き継ぐ資産と、無いもの
+
+### そのまま使える（フォークに含まれる）
+
+- Twilio Media Streams ↔ OpenAI Realtimeブリッジ（`index.js`）
+- 発話記録 `session.turns`（話者・本文・時刻）＝**評価の入力データ**
+- 構造化抽出パターン（`extractCallDetails` のjson_schema）＝評価ルーブリックへの転用元
+- 入力ゲート・VAD設定・終話ワークフロー・署名検証・監査ログ・Cloud Runデプロイ・React管理UI
+
+### 本リポジトリに存在しない（新規実装が必要）
+
+- **録音・音声tee**: 現行は音声をOpenAIへ転送するのみで、いかなる形でも保存していない。練習者音声（Twilio inboundトラックのみ）のWAV録音またはリアルタイムteeを新規実装する
+- **μ-law→PCM変換**: Emotion Logicリアルタイム連携用（8kHzはそのまま使える。emotion-logic-api-notes.md参照）
+- **評価エンジン**: 下記3系統の統合
+- **シナリオ管理・マルチテナント・課金**: SaaS基盤
+
+## 評価エンジン（フル実装方針）
+
+要件定義書の3系統統合。各軸に `confidence` と `evidence`（根拠へのポインタ）を必ず持たせる。
+
+| 評価軸 | 担い手 | 入力 | 備考 |
+|---|---|---|---|
+| 声のトーン・感情・共感・緊張 | Emotion Logic | 練習者音声（inboundのみ） | PoC=通話後 `analyzeFile`、本番=EMLO Dockerリアルタイムを検証 |
+| 話速・間 | 自前計算 | `turns`（本文＋時刻） | 文字数÷発話秒数。**既存データだけで実装可能、最初に作る** |
+| 言葉遣い・敬語・マニュアル順守 | 文字起こし×LLM（json_schema） | 文字起こし＋マニュアル | `extractCallDetails` パターンを評価スキーマへ差し替え |
+
+### 実装順の推奨
+
+1. **話速評価**（既存turnsのみで完成。最小の差別化を最速で実証）
+2. **LLM内容評価**（既存の構造化抽出パターン転用）
+3. **Emotion Logic連携**（録音実装→`dummyResponse=true`で開発→通話後解析→8kHz感度のPoC実測→リアルタイム化判断）
+
+## 新リポジトリの初期issue一覧（起票用）
+
+1. リポジトリ初期化: フォーク、プロンプトをAI顧客役へ差し替え、不要機能（handoff等）の無効化
+2. GCPプロジェクト構築: API有効化、Secret Manager、Firestore、Cloud Runデプロイ
+3. 着信受口: DTMFゲートウェイからの `<Redirect>` を受けるTwiML + 練習セッション開始
+4. 同意フロー: 練習開始前の録音・外部送信同意（`consentObtainedFromDataSubject` と整合）
+5. 録音/tee: Twilio inboundトラックのWAV録音（話者分離）
+6. 話速・間の評価: turnsからの算出とスコア化
+7. LLM内容評価: 評価ルーブリックjson_schemaと通話後採点
+8. Emotion Logic通話後解析: `analyzeFile` 連携（`dummyResponse` で開発→実解析）
+9. 8kHz感度PoC: 電話音声 vs 広帯域録音の実測比較（要件定義書10.5）
+10. 評価統合レポート: 3系統統合スコア+根拠提示、フィードバック画面
+11. 1通話原価の実測: Realtime累積トークン+Emotion Logic単価（要件定義書11章の更新）
+12. μ-law→PCM変換とEMLO Dockerリアルタイム解析の検証（本番方式の判断、ADR化）
+
+## プライバシー要件（受付システムより厳格）
+
+- 練習者音声の録音と外部送信（Emotion Logicクラウド利用時）が発生するため、同意取得フロー・RHSとのDPA・保持期間/削除ポリシーが必須（要件定義書13章）
+- EMLO Docker（セルフホスト）なら音声を自社インフラ内で処理でき、第三者提供の論点を軽減できる。PoC後の本番方式判断で考慮する
+- テナント間データ分離（`tenantId` 必須クエリ）をスキーマ段階から設計する


### PR DESCRIPTION
## 概要

ADR-0008（PR #56）の実装設計docと、練習システム新リポジトリへの引き継ぎ資料を追加します。Wave E1/E2の実装エージェント向け仕様です。

## 変更内容

- **dtmf-gateway-design.md 新規**: `/incoming-call` への `<Gather input=dtmf>` 挿入設計。DTMF `5`（終端 `#`）で練習システムへ `<Redirect>`、無入力は従来AI受付、`DTMF_GATEWAY_ENABLED` 既定false、URL未設定時fail safe、既存入力ゲートとの非干渉
- **emotion-logic-api-notes.md 新規**: Emotion Logic（旧称ALICe、RHS経由・NDA/キー発行済み）のAPI仕様調査結果。ファイル解析（analyzeFile/analyzeFromURL、dummyResponseで課金なし開発、segmentsにturns転用可）、リアルタイム解析（EMLO Docker、socket.io、PCM 8kHz対応）、μ-law→PCM変換、同意必須パラメータ。**キー実値なし（Secret Manager名のみ）**
- **practice-system-handover.md 新規**: 新リポ（フォーク+別GCPプロジェクト）立ち上げチェックリスト、本リポに録音機能が無い事実、評価エンジン3系統（話速→LLM→Emotion Logicの実装順）、新リポ初期issue一覧12本、プライバシー要件

## 検証

- `npm test` 通過（37 tests / 0 fail）
- 秘匿情報検査済み: APIキー/パスワード実値・電話番号なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)