### PR TITLE
Fix voice interruption, phone capture, and general handoff

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,4 +87,4 @@ NOTIFY_EMAIL_FROM=noreply@cor-jp.com
 # === System message (override per deployment) ===
 # SYSTEM_MESSAGE=
 # SYSTEM_MESSAGE_FILE=
-# FIRST_MESSAGE=
+# FIRST_MESSAGE=お電話ありがとうございます。Cor.株式会社のお電話受付です。ご用件をお聞かせください。

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ import {
     buildTransferToHumanTool,
     HandoffContextStore,
     summarizeHandoffTurns,
+    shouldAutoHandoffGeneral,
     updateTwilioCallTwiml
 } from './lib/handoff.js';
 import { NotificationOutbox } from './lib/notification-outbox.js';
@@ -68,8 +69,11 @@ const ADMIN_APP_INDEX_PATH = join(ADMIN_APP_DIST_DIR, 'index.html');
 const DEFAULT_SYSTEM_MESSAGE = [
     'あなたは日本のコールセンターで電話一次受付を担当するAIオペレーターです。',
     '必ず自然で丁寧な日本語だけで応答してください。英語では応答しません。',
+    '通常は「Cor.株式会社のお電話受付です」と名乗り、自分からAI・人工知能・システムとは名乗らないでください。AIかどうかを尋ねられた場合は正直に答え、希望があれば担当者へ引き継いでください。',
+    '相手が話し始めたら自分の発話を止めて聞いてください。相手の発話に重ねて話さず、特に電話番号の途中で応答や質問を差し込まないでください。',
     '相手の発話が聞き取れない場合は、推測せず「恐れ入ります。もう一度お話しいただけますか」と確認してください。',
     '一度に複数の質問をせず、用件、名前、折り返し電話番号、希望日時などを一つずつ確認してください。',
+    '電話番号は相手が最後まで話し終えてから確認してください。途中で区切れた場合は、3〜4桁ずつ続けて話してもらい、複数回の発話を1つの番号として確認して構いません。',
     '氏名は聞こえた読みをそのままカタカナで確認してください。一般的な漢字名へ勝手に変換しないでください。',
     '氏名が少しでも不確かな場合は「お名前の読みをカタカナで確認させてください」と聞き返してください。',
     '会話を勝手に終了せず、必要に応じて担当者へ引き継ぐ旨を伝え、受付完了時は終話ルールに従って案内してください。',
@@ -132,7 +136,7 @@ const {
     RESEND_API_KEY = '',
     SYSTEM_MESSAGE = DEFAULT_SYSTEM_MESSAGE,
     SYSTEM_MESSAGE_FILE = '',
-    FIRST_MESSAGE = 'お電話ありがとうございます。AI受付です。どのようなご用件でしょうか。',
+    FIRST_MESSAGE = 'お電話ありがとうございます。Cor.株式会社のお電話受付です。ご用件をお聞かせください。',
     CALL_END_WORKFLOW_ENABLED = 'true',
     CALL_END_HANGUP_ENABLED = 'true',
     CALL_END_FINAL_PHRASE = '',
@@ -877,7 +881,12 @@ fastify.register(async (fastify) => {
                 event,
                 state: session,
                 callEndConfig: CALL_END_CONFIG,
-                handoffConfig: HANDOFF_CONFIG
+                handoffConfig: HANDOFF_CONFIG,
+                onPhoneValidation: (metadata) => auditLog('callback_phone.validation', {
+                    actor: 'realtime',
+                    target: session.callSid || sessionId,
+                    metadata
+                })
             });
             if (!result.handled) return false;
 
@@ -910,6 +919,21 @@ fastify.register(async (fastify) => {
             openAiWs.send(JSON.stringify({ type: 'response.create' }));
             if (SHOULD_LOG_REALTIME_EVENTS) {
                 console.log(`Sent response.create (${reason})`);
+            }
+        };
+
+        const interruptAssistantResponse = () => {
+            if (responseInProgress && openAiWs.readyState === WebSocket.OPEN) {
+                openAiWs.send(JSON.stringify({ type: 'response.cancel' }));
+            }
+
+            pendingResponseAfterCurrent = false;
+
+            if (session.streamSid && connection.readyState === WebSocket.OPEN) {
+                connection.send(JSON.stringify({
+                    event: 'clear',
+                    streamSid: session.streamSid
+                }));
             }
         };
 
@@ -985,6 +1009,33 @@ fastify.register(async (fastify) => {
                     if (SHOULD_LOG_TRANSCRIPTS && gateResult.normalized) {
                         console.log(`User (${sessionId}): ${gateResult.normalized}`);
                     }
+
+                    if (
+                        HANDOFF_CONFIG.enabled
+                        && !session.handoff?.started
+                        && !session.handoff?.starting
+                        && shouldAutoHandoffGeneral(session.turns)
+                    ) {
+                        session.handoff = {
+                            ...(session.handoff || {}),
+                            starting: true,
+                            trigger: 'general_business_dispute'
+                        };
+                        auditLog('handoff.auto_triggered', {
+                            actor: 'system',
+                            target: session.callSid || sessionId,
+                            metadata: {
+                                destination: 'general',
+                                reason: 'general_business_dispute'
+                            }
+                        });
+                        void startHandoff({
+                            reason: '料金・既存取引に関する人間対応',
+                            destination: 'general'
+                        });
+                        return;
+                    }
+
                     if (SHOULD_GATE_REALTIME_INPUT) {
                         sendRealtimeResponseCreate(`accepted_transcript:${gateResult.reason}`);
                     }
@@ -1004,6 +1055,10 @@ fastify.register(async (fastify) => {
 
                 if (response.type === 'session.updated') {
                     console.log('Realtime session updated successfully');
+                }
+
+                if (response.type === 'input_audio_buffer.speech_started') {
+                    interruptAssistantResponse();
                 }
 
                 if (response.type === 'response.created') {

--- a/lib/handoff.js
+++ b/lib/handoff.js
@@ -4,6 +4,12 @@ const ACCOUNT_SID_PATTERN = /^AC[a-fA-F0-9]{32}$/;
 const CALL_SID_PATTERN = /^CA[a-fA-F0-9]{32}$/;
 const HANDOFF_DESTINATIONS = Object.freeze(['contract', 'general']);
 const normalizeText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
+const GENERAL_HANDOFF_PATTERNS = [
+    /(料金|金額|支払|支払い|請求|入金|返金|取引)[^。！？\n]{0,24}(不足|足り|差額|違|間違|確認|相談|返金)/,
+    /(不足|足り|差額|違|間違)[^。！？\n]{0,24}(料金|金額|支払|支払い|請求|入金|取引)/,
+    /(代表|責任者|担当者)[^。！？\n]{0,20}(話|相談|つな|繋|希望|お願い)/,
+    /(苦情|クレーム|強い不満|納得できない)/
+];
 
 export function normalizeHandoffDestination(value) {
     return String(value || '').trim().toLowerCase() === 'contract' ? 'contract' : 'general';
@@ -12,7 +18,7 @@ export function normalizeHandoffDestination(value) {
 const functionTool = {
     type: 'function',
     name: 'transfer_to_human',
-    description: '担当者への電話転送を開始します。人間対応の明示要求、解決困難な問い合わせ、または高い感情的負荷がある場合に使用します。',
+    description: '担当者への電話転送を開始します。人間対応の明示要求、料金・支払・請求・既存取引の相違、解決困難な問い合わせ、または高い感情的負荷がある場合に使用します。',
     parameters: {
         type: 'object',
         properties: {
@@ -23,7 +29,7 @@ const functionTool = {
             destination: {
                 type: 'string',
                 enum: HANDOFF_DESTINATIONS,
-                description: 'contractは受託案件・開発制作・仕事の依頼、generalはそれ以外の人間対応です。'
+                description: 'contractは受託案件・開発制作・仕事の依頼、generalは料金・支払・請求・既存取引の相違、苦情、代表/責任者への相談など、それ以外の人間対応です。'
             }
         },
         required: ['reason', 'destination'],
@@ -90,11 +96,21 @@ export function appendHandoffInstructions(instructions, config = {}) {
         [
             '人間の担当者への転送が必要な場合は transfer_to_human を使ってください。',
             '受託案件、開発・制作、業務委託、見積相談など仕事の依頼は destination="contract" を指定してください。',
-            'その他の人間対応が必要な問い合わせ、明示的な担当者希望、強い不安・怒り・苦情は destination="general" を指定してください。',
+            '料金不足、支払・請求・入金・返金の相違、既存取引への苦情、代表・責任者への相談、強い不安・怒り・苦情は destination="general" を指定し、氏名や折り返し番号を先に聞かず、すぐに転送してください。',
             '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで受付し、transfer_to_humanを使わずに内容を記録してください。',
             '転送ツール実行後は、電話を切らずに担当者へつなぐ案内を短く行ってください。'
         ].join('\n')
     ].join('\n\n');
+}
+
+export function shouldAutoHandoffGeneral(turns = []) {
+    const recentUserText = turns
+        .filter((turn) => turn?.role === 'user')
+        .slice(-6)
+        .map((turn) => normalizeText(turn.text))
+        .join(' ');
+
+    return GENERAL_HANDOFF_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
 export function findTransferToHumanToolCalls(event) {

--- a/lib/phone-number-validation.js
+++ b/lib/phone-number-validation.js
@@ -94,6 +94,41 @@ export function formatSpokenPhoneDigits(phoneNumber) {
     return digitsOnly(String(phoneNumber || '')).split('').join('、');
 }
 
+export function extractPhoneDigits(value) {
+    return digitsOnly(normalizeInput(value));
+}
+
+export function appendPhoneDigitFragments(previous, current) {
+    const previousDigits = extractPhoneDigits(previous);
+    const currentDigits = extractPhoneDigits(current);
+    if (!previousDigits) return currentDigits;
+    if (!currentDigits) return previousDigits;
+
+    const maxOverlap = Math.min(previousDigits.length, currentDigits.length);
+    for (let overlap = maxOverlap; overlap > 0; overlap -= 1) {
+        if (previousDigits.endsWith(currentDigits.slice(0, overlap))) {
+            return previousDigits + currentDigits.slice(overlap);
+        }
+    }
+
+    return previousDigits + currentDigits;
+}
+
+export function recoverRepeatedJapaneseCallbackPhoneNumber(value) {
+    const digits = extractPhoneDigits(value);
+    for (const phoneLength of [MIN_CALLBACK_PHONE_DIGITS, MAX_CALLBACK_PHONE_DIGITS]) {
+        if (digits.length <= phoneLength || digits.length % phoneLength !== 0) continue;
+
+        const firstNumber = digits.slice(0, phoneLength);
+        if (firstNumber.repeat(digits.length / phoneLength) !== digits) continue;
+
+        const validation = validateJapaneseCallbackPhoneNumber(firstNumber);
+        if (validation.valid) return validation;
+    }
+
+    return null;
+}
+
 export function extractJapanesePhoneCandidates(value) {
     const normalizedInput = normalizeInput(value);
     const candidates = [];
@@ -225,7 +260,7 @@ export function buildValidateCallbackPhoneTool() {
             properties: {
                 heard_phone_number: {
                     type: 'string',
-                    description: 'The callback phone number phrase exactly as heard from the customer.'
+                    description: 'The latest callback phone number phrase exactly as heard from the customer. Include only one utterance; do not include previous turns, instructions, confirmation text, or repeated attempts.'
                 }
             },
             required: ['heard_phone_number']
@@ -239,6 +274,8 @@ export function appendCallbackPhoneValidationInstructions(systemMessage) {
         [
             '電話番号確認ルール:',
             '折り返し先の電話番号を聞いたら、番号を復唱する前に必ず validate_callback_phone ツールを呼び出してください。',
+            'heard_phone_numberには顧客が直前に話した電話番号の発話だけを入れ、過去の会話、指示文、確認文、複数回分の番号を連結してはいけません。',
+            '顧客が番号を話している途中で発話を差し込まず、発話が終わってからツールを呼び出してください。',
             '顧客が言っていない 090、080、市外局番、末尾番号を補完してはいけません。',
             'validate_callback_phone が valid=false を返した場合は、返された clarificationPrompt をそのまま自然に読み上げ、もう一度番号を聞いてください。',
             'validate_callback_phone が valid=true を返した場合だけ、返された confirmationPrompt で確認してください。',

--- a/lib/realtime-tool-flow.js
+++ b/lib/realtime-tool-flow.js
@@ -1,5 +1,9 @@
 import {
+    appendPhoneDigitFragments,
+    extractJapanesePhoneCandidates,
+    extractPhoneDigits,
     findValidateCallbackPhoneToolCalls,
+    recoverRepeatedJapaneseCallbackPhoneNumber,
     validateJapaneseCallbackPhoneNumber
 } from './phone-number-validation.js';
 import { findFinishReceptionToolCalls } from './realtime-call-end.js';
@@ -18,7 +22,8 @@ export function handleRealtimeToolCalls({
     event,
     state,
     callEndConfig,
-    handoffConfig = { enabled: false, numbers: [] }
+    handoffConfig = { enabled: false, numbers: [] },
+    onPhoneValidation = null
 }) {
     const outputs = [];
     const callEndRequests = [];
@@ -28,7 +33,37 @@ export function handleRealtimeToolCalls({
     const phoneToolCalls = findValidateCallbackPhoneToolCalls(event);
     if (phoneToolCalls.length > 0) {
         for (const toolCall of phoneToolCalls) {
-            const validation = validateJapaneseCallbackPhoneNumber(toolCall.heardPhoneNumber);
+            const rawValidation = validateJapaneseCallbackPhoneNumber(toolCall.heardPhoneNumber);
+            let validation = recoverRepeatedJapaneseCallbackPhoneNumber(toolCall.heardPhoneNumber)
+                || rawValidation;
+            let captureAction = validation !== rawValidation ? 'recovered_repeated' : 'direct';
+            const currentDigits = extractPhoneDigits(toolCall.heardPhoneNumber);
+            const previousDigits = toolState.callbackPhoneCapture?.digits || '';
+
+            if (!validation.valid && ['no_candidate', 'too_short'].includes(rawValidation.reason) && currentDigits) {
+                const combinedDigits = appendPhoneDigitFragments(previousDigits, currentDigits);
+                const combinedInput = combinedDigits.startsWith('81') ? `+${combinedDigits}` : combinedDigits;
+                const combinedValidation = validateJapaneseCallbackPhoneNumber(combinedInput);
+
+                if (combinedValidation.valid) {
+                    validation = combinedValidation;
+                    captureAction = 'combined_fragments';
+                    delete toolState.callbackPhoneCapture;
+                } else if (combinedDigits.length < 11) {
+                    toolState.callbackPhoneCapture = {
+                        digits: combinedDigits,
+                        updatedAt: new Date().toISOString()
+                    };
+                    captureAction = 'buffered_fragment';
+                } else {
+                    delete toolState.callbackPhoneCapture;
+                }
+            } else if (validation.valid) {
+                delete toolState.callbackPhoneCapture;
+            } else if (rawValidation.reason === 'too_long') {
+                delete toolState.callbackPhoneCapture;
+            }
+
             toolState.callbackPhone = validation.valid
                 ? {
                     valid: true,
@@ -40,6 +75,20 @@ export function handleRealtimeToolCalls({
                     reason: validation.reason,
                     validatedAt: new Date().toISOString()
                 };
+
+            if (typeof onPhoneValidation === 'function') {
+                onPhoneValidation({
+                    callId: toolCall.callId,
+                    reason: validation.reason,
+                    rawReason: rawValidation.reason,
+                    captureAction,
+                    inputChars: toolCall.heardPhoneNumber.length,
+                    inputDigits: currentDigits.length,
+                    candidateCount: extractJapanesePhoneCandidates(toolCall.heardPhoneNumber).length,
+                    bufferedDigits: toolState.callbackPhoneCapture?.digits.length || 0,
+                    valid: validation.valid
+                });
+            }
 
             outputs.push(functionCallOutputItem(toolCall.callId, {
                 valid: validation.valid,

--- a/lib/twiml.js
+++ b/lib/twiml.js
@@ -96,7 +96,7 @@ export function buildWhisperTwiml({
     return `<?xml version="1.0" encoding="UTF-8"?>
 <Response>
   <Gather input="dtmf" numDigits="1" timeout="${escapeXml(timeoutSeconds)}" finishOnKey="#"${xmlAttribute('action', confirmUrl)} method="POST">
-    <Say language="ja-JP">AI受付からの引き継ぎです。${escapeXml(summary)}。接続する場合は${escapeXml(acceptDigit)}を押してください。</Say>
+    <Say language="ja-JP">Cor.株式会社のお電話受付からの引き継ぎです。${escapeXml(summary)}。接続する場合は${escapeXml(acceptDigit)}を押してください。</Say>
   </Gather>
   <Hangup />
 </Response>`;

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -6,6 +6,7 @@ import {
     buildTransferToHumanTool,
     findTransferToHumanToolCalls,
     HandoffContextStore,
+    shouldAutoHandoffGeneral,
     summarizeHandoffTurns,
     updateTwilioCallTwiml
 } from '../lib/handoff.js';
@@ -69,6 +70,18 @@ test('handoff summary uses recent turns and caps its length', () => {
     assert.match(summary, /発信者/);
     assert.match(summary, /担当者に相談したいです/);
     assert.ok(summary.length < 700);
+});
+
+test('handoff auto-detects billing disputes and representative requests', () => {
+    assert.equal(shouldAutoHandoffGeneral([
+        { role: 'user', text: '以前の取引について、支払った料金が足りなかったので相談したいです。' }
+    ]), true);
+    assert.equal(shouldAutoHandoffGeneral([
+        { role: 'user', text: '代表の方に直接相談したいです。' }
+    ]), true);
+    assert.equal(shouldAutoHandoffGeneral([
+        { role: 'user', text: '採用について質問があります。' }
+    ]), false);
 });
 
 test('Twilio call update sends TwiML with basic authentication', async () => {

--- a/test/phone-number-validation.test.js
+++ b/test/phone-number-validation.test.js
@@ -1,11 +1,14 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 import {
+    appendPhoneDigitFragments,
     appendCallbackPhoneValidationInstructions,
     buildValidateCallbackPhoneTool,
     extractJapanesePhoneCandidates,
+    extractPhoneDigits,
     formatSpokenPhoneDigits,
     findValidateCallbackPhoneToolCalls,
+    recoverRepeatedJapaneseCallbackPhoneNumber,
     validateJapaneseCallbackPhoneNumber
 } from '../lib/phone-number-validation.js';
 
@@ -73,6 +76,16 @@ test('callback phone validation rejects suspicious or over-expanded numbers', ()
     assert.equal(repeated.reason, 'suspicious_model_expanded_number');
 });
 
+test('callback phone helpers recover repeated model arguments and merge overlapping fragments', () => {
+    const recovered = recoverRepeatedJapaneseCallbackPhoneNumber('0901234567809012345678');
+
+    assert.equal(recovered.valid, true);
+    assert.equal(recovered.normalizedPhoneNumber, '09012345678');
+    assert.equal(appendPhoneDigitFragments('090', '0901234'), '0901234');
+    assert.equal(appendPhoneDigitFragments('0901234', '12345678'), '09012345678');
+    assert.equal(extractPhoneDigits('０９０ー１２３４ー５６７８'), '09012345678');
+});
+
 test('callback phone validation asks for clarification when multiple phone numbers are heard', () => {
     const result = validateJapaneseCallbackPhoneNumber('090-1234-5678 または 080-1111-2222');
 
@@ -96,6 +109,7 @@ test('callback phone validation exposes Realtime tool schema and instructions', 
     assert.equal(tool.name, 'validate_callback_phone');
     assert.deepEqual(tool.parameters.required, ['heard_phone_number']);
     assert.match(instructions, /validate_callback_phone/);
+    assert.match(instructions, /直前に話した電話番号/);
     assert.match(instructions, /補完してはいけません/);
 });
 

--- a/test/realtime-tool-flow.test.js
+++ b/test/realtime-tool-flow.test.js
@@ -33,6 +33,67 @@ test('Realtime tool flow validates callback phone before assistant confirmation'
     assert.equal(state.callbackPhone.valid, true);
 });
 
+test('Realtime tool flow combines callback phone fragments across interrupted turns', () => {
+    const state = {};
+    const validationEvents = [];
+
+    for (const [callId, heardPhoneNumber] of [
+        ['phone_fragment_1', '090'],
+        ['phone_fragment_2', '1234'],
+        ['phone_fragment_3', '5678']
+    ]) {
+        const result = handleRealtimeToolCalls({
+            event: toolEvent('validate_callback_phone', callId, { heard_phone_number: heardPhoneNumber }),
+            state,
+            callEndConfig: buildCallEndConfig(),
+            onPhoneValidation: (metadata) => validationEvents.push(metadata)
+        });
+        const output = JSON.parse(result.outputs[0].item.output);
+
+        if (callId !== 'phone_fragment_3') {
+            assert.equal(output.valid, false);
+        } else {
+            assert.equal(output.valid, true);
+            assert.equal(output.normalizedPhoneNumber, '09012345678');
+        }
+    }
+
+    assert.equal(state.callbackPhone.valid, true);
+    assert.equal(state.callbackPhoneCapture, undefined);
+    assert.deepEqual(validationEvents.map((event) => event.captureAction), [
+        'buffered_fragment',
+        'buffered_fragment',
+        'combined_fragments'
+    ]);
+});
+
+test('Realtime tool flow reports safe metadata for an over-expanded phone argument', () => {
+    const validationEvents = [];
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('validate_callback_phone', 'phone_repeated', {
+            heard_phone_number: '0901234567809012345678'
+        }),
+        state: {},
+        callEndConfig: buildCallEndConfig(),
+        onPhoneValidation: (metadata) => validationEvents.push(metadata)
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.equal(output.valid, true);
+    assert.equal(output.normalizedPhoneNumber, '09012345678');
+    assert.deepEqual(validationEvents[0], {
+        callId: 'phone_repeated',
+        reason: 'valid',
+        rawReason: 'too_long',
+        captureAction: 'recovered_repeated',
+        inputChars: 22,
+        inputDigits: 22,
+        candidateCount: 1,
+        bufferedDigits: 0,
+        valid: true
+    });
+});
+
 test('Realtime tool flow rejects invalid callback phone fragments', () => {
     const state = {};
     const result = handleRealtimeToolCalls({

--- a/test/twiml.test.js
+++ b/test/twiml.test.js
@@ -64,6 +64,13 @@ test('whisper confirmation keeps accepted leg connected and hangs up rejection',
     assert.match(buildWhisperTwiml({ summary: '資料請求', confirmUrl: 'https://voice.example/confirm' }), /資料請求/);
 });
 
+test('whisper identifies the company reception without exposing AI wording', () => {
+    const body = buildWhisperTwiml({ summary: '資料請求', confirmUrl: 'https://voice.example/confirm' });
+
+    assert.match(body, /Cor\.株式会社のお電話受付からの引き継ぎ/);
+    assert.doesNotMatch(body, /AI受付/);
+});
+
 test('dial status TwiML distinguishes connected and fallback calls', () => {
     assert.match(buildDialStatusTwiml({ connected: true }), /Hangup/);
     assert.match(buildDialStatusTwiml({ connected: false }), /折り返し/);


### PR DESCRIPTION
## Summary

Fixes the two UAT issues found in call `CA874ec0c1a4e4b5e1025f1681a45577dc`.

## Root cause from the call log

- The caller's callback number was transcribed as 11 digits on all three attempts. Audio capture did not lose the digits.
- The realtime phone-validation path treated the model's repeated/expanded argument as too long, so the assistant kept asking for the same number.
- The previous flow asked for the callback number before applying a general handoff rule. The billing/payment shortfall case therefore never invoked `transfer_to_human`, and no representative transfer occurred.
- The original greeting explicitly said `AI受付`.

## Changes

- Use the company greeting: `Cor.株式会社のお電話受付です`.
- Stop an in-progress assistant response when caller speech starts and clear the Twilio media stream buffer.
- Recover repeated phone-number arguments and accumulate valid 3–4 digit fragments without logging PII.
- Add non-PII phone-validation audit metadata for diagnosis.
- Automatically hand off billing/payment disputes, existing-transaction discrepancies, representative requests, and strong complaints to the general representative path before requesting callback details.
- Update the transfer whisper to company wording.

## Verification

- `npm test`: 58 tests passed, 0 failed.
- `git diff --check`: passed.
- Secret scan excluding local environment files: no secret values found.
- Raw phone tool arguments remain out of logs; only non-PII validation metadata is emitted.

## UAT follow-up

After merge and deployment, verify by real call:
1. Company greeting and caller interruption.
2. Billing/payment discrepancy reaches the representative number.
3. Callback-number capture accepts a normal 11-digit number and fragmented speech.
4. Existing employment/sales inquiries still use the AI/Resend path as intended.
