### PR TITLE
Keep sales calls in call center

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,7 @@ import {
     HandoffContextStore,
     summarizeHandoffTurns,
     shouldAutoHandoffGeneral,
+    isNonHandoffBusinessCall,
     updateTwilioCallTwiml
 } from './lib/handoff.js';
 import { NotificationOutbox } from './lib/notification-outbox.js';
@@ -77,7 +78,7 @@ const DEFAULT_SYSTEM_MESSAGE = [
     '氏名は聞こえた読みをそのままカタカナで確認してください。一般的な漢字名へ勝手に変換しないでください。',
     '氏名が少しでも不確かな場合は「お名前の読みをカタカナで確認させてください」と聞き返してください。',
     '会話を勝手に終了せず、必要に応じて担当者へ引き継ぐ旨を伝え、受付完了時は終話ルールに従って案内してください。',
-    '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。',
+    '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。営業・採用提案は担当者へ報告し、必要があれば担当者から折り返すと案内してください。明確な折り返し希望がなければ、折り返し番号を聞かずcallback_required=falseで受付を完了してください。',
     '受託案件、開発・制作、業務委託、見積相談など仕事の依頼で人間対応が必要な場合は、transfer_to_humanをdestination="contract"で使用してください。',
     'それ以外で人間対応が必要な場合は、transfer_to_humanをdestination="general"で使用してください。',
     'まだ社名や業務ナレッジが未設定のため、断定できない内容は「確認して折り返します」と案内してください。'
@@ -992,11 +993,15 @@ fastify.register(async (fastify) => {
         };
 
         const handleToolCalls = (event) => {
+            const nonHandoffBusinessCall = isNonHandoffBusinessCall(session.turns);
             const result = handleRealtimeToolCalls({
                 event,
                 state: session,
                 callEndConfig: CALL_END_CONFIG,
-                handoffConfig: HANDOFF_CONFIG,
+                handoffConfig: {
+                    ...HANDOFF_CONFIG,
+                    blockNonHandoffBusiness: nonHandoffBusinessCall
+                },
                 onPhoneValidation: (metadata) => auditLog('callback_phone.validation', {
                     actor: 'realtime',
                     target: session.callSid || sessionId,
@@ -1010,6 +1015,13 @@ fastify.register(async (fastify) => {
             }
             for (const callEndRequest of result.callEndRequests) {
                 requestCallEnd(callEndRequest);
+            }
+            if (nonHandoffBusinessCall && result.responseReason === 'transfer_to_human_tool_output') {
+                auditLog('handoff.blocked_by_business_policy', {
+                    actor: 'system',
+                    target: session.callSid || sessionId,
+                    metadata: { policy: 'non_handoff_business' }
+                });
             }
             if (result.handoffRequests.length > 0) {
                 void startHandoff(result.handoffRequests[0]);
@@ -1140,6 +1152,7 @@ fastify.register(async (fastify) => {
                         HANDOFF_CONFIG.enabled
                         && !session.handoff?.started
                         && !session.handoff?.starting
+                        && !isNonHandoffBusinessCall(session.turns)
                         && shouldAutoHandoffGeneral(session.turns)
                     ) {
                         session.handoff = {

--- a/lib/handoff.js
+++ b/lib/handoff.js
@@ -10,6 +10,13 @@ const GENERAL_HANDOFF_PATTERNS = [
     /(代表|責任者|担当者)[^。！？\n]{0,20}(話|相談|つな|繋|希望|お願い)/,
     /(苦情|クレーム|強い不満|納得できない)/
 ];
+const NON_HANDOFF_BUSINESS_PATTERNS = [
+    /(営業|営業電話|勧誘|広告|売り込み|テレアポ|アポイント)/,
+    /(紹介料|アサイン|採用サポート|採用支援|人材紹介)/,
+    /(採用|人材|エンジニア)[^。！？\n]{0,60}(紹介|アサイン|採用サポート|採用支援|紹介料|ご提案)/,
+    /(?:弊社|当社)[^。！？\n]{0,40}(ご提案|ご紹介|サービス|システム|営業)/,
+    /(従来より|通常より|他社より)[^。！？\n]{0,20}(安|抑|割引|低)/
+];
 
 export function normalizeHandoffDestination(value) {
     return String(value || '').trim().toLowerCase() === 'contract' ? 'contract' : 'general';
@@ -96,8 +103,9 @@ export function appendHandoffInstructions(instructions, config = {}) {
         [
             '人間の担当者への転送が必要な場合は transfer_to_human を使ってください。',
             '受託案件、開発・制作、業務委託、見積相談など仕事の依頼は destination="contract" を指定してください。',
-            '料金不足、支払・請求・入金・返金の相違、既存取引への苦情、代表・責任者への相談、強い不安・怒り・苦情は destination="general" を指定し、氏名や折り返し番号を先に聞かず、すぐに転送してください。',
-            '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで受付し、transfer_to_humanを使わずに内容を記録してください。',
+            '料金不足、支払・請求・入金・返金の相違、既存取引への苦情、強い不安・怒り・苦情は destination="general" を指定し、氏名や折り返し番号を先に聞かず、すぐに転送してください。',
+            '代表・責任者への相談は、営業・採用・勧誘・広告ではなく、料金・既存取引の相違や明確な苦情など人間対応が必要な場合だけ destination="general" で転送してください。',
+            '採用応募・採用関連、営業・勧誘・広告、一般的な案内は転送せず、AIで内容を受付・記録してください。担当者へ報告し、必要があれば担当者から折り返すと案内してください。発信者が明確に折り返しを希望しない限り、callback_required=falseで終話してください。',
             '転送ツール実行後は、電話を切らずに担当者へつなぐ案内を短く行ってください。'
         ].join('\n')
     ].join('\n\n');
@@ -111,6 +119,16 @@ export function shouldAutoHandoffGeneral(turns = []) {
         .join(' ');
 
     return GENERAL_HANDOFF_PATTERNS.some((pattern) => pattern.test(recentUserText));
+}
+
+export function isNonHandoffBusinessCall(turns = []) {
+    const recentUserText = turns
+        .filter((turn) => turn?.role === 'user')
+        .slice(-8)
+        .map((turn) => normalizeText(turn.text))
+        .join(' ');
+
+    return NON_HANDOFF_BUSINESS_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
 export function findTransferToHumanToolCalls(event) {

--- a/lib/realtime-tool-flow.js
+++ b/lib/realtime-tool-flow.js
@@ -114,12 +114,17 @@ export function handleRealtimeToolCalls({
 
     const handoffToolCalls = findTransferToHumanToolCalls(event);
     if (handoffToolCalls.length > 0) {
-        if (!handoffConfig.enabled || handoffConfig.numbers.length === 0) {
+        const handoffBlockedByBusinessPolicy = handoffConfig.blockNonHandoffBusiness === true;
+        if (handoffBlockedByBusinessPolicy || !handoffConfig.enabled || handoffConfig.numbers.length === 0) {
             for (const toolCall of handoffToolCalls) {
                 outputs.push(functionCallOutputItem(toolCall.callId, {
                     ok: false,
-                    reason: 'handoff_unavailable',
-                    instruction: '担当者への転送機能が現在利用できません。転送できない旨を丁寧に案内し、受付内容を記録してください。'
+                    reason: handoffBlockedByBusinessPolicy
+                        ? 'non_handoff_business_call'
+                        : 'handoff_unavailable',
+                    instruction: handoffBlockedByBusinessPolicy
+                        ? '営業・採用・勧誘・広告の受付なので電話転送は行いません。内容を担当者へ報告し、必要があれば担当者から折り返すと案内してください。明確な折り返し希望がなければcallback_required=falseのfinish_receptionで受付を完了してください。'
+                        : '担当者への転送機能が現在利用できません。転送できない旨を丁寧に案内し、受付内容を記録してください。'
                 }));
             }
         } else {

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -6,6 +6,7 @@ import {
     buildTransferToHumanTool,
     findTransferToHumanToolCalls,
     HandoffContextStore,
+    isNonHandoffBusinessCall,
     shouldAutoHandoffGeneral,
     summarizeHandoffTurns,
     updateTwilioCallTwiml
@@ -81,6 +82,15 @@ test('handoff auto-detects billing disputes and representative requests', () => 
     ]), true);
     assert.equal(shouldAutoHandoffGeneral([
         { role: 'user', text: '採用について質問があります。' }
+    ]), false);
+});
+
+test('handoff policy blocks recruiting sales proposals but keeps contract requests eligible', () => {
+    assert.equal(isNonHandoffBusinessCall([
+        { role: 'user', text: '弊社でエンジニアの採用サポートをしており、紹介料を抑えてアサインできます。' }
+    ]), true);
+    assert.equal(isNonHandoffBusinessCall([
+        { role: 'user', text: 'システム開発を依頼したいので、見積もりを相談したいです。' }
     ]), false);
 });
 

--- a/test/realtime-tool-flow.test.js
+++ b/test/realtime-tool-flow.test.js
@@ -183,3 +183,26 @@ test('Realtime tool flow emits a handoff request only when enabled with recipien
     assert.equal(output.status, 'starting');
     assert.equal(output.destination, 'contract');
 });
+
+test('Realtime tool flow blocks human transfer for non-handoff business calls', () => {
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('transfer_to_human', 'handoff_sales_1', {
+            reason: '採用支援サービスの営業提案',
+            destination: 'general'
+        }),
+        state: {},
+        callEndConfig: buildCallEndConfig(),
+        handoffConfig: {
+            enabled: true,
+            numbers: ['+819012345678'],
+            blockNonHandoffBusiness: true
+        }
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.equal(result.handled, true);
+    assert.deepEqual(result.handoffRequests, []);
+    assert.equal(output.ok, false);
+    assert.equal(output.reason, 'non_handoff_business_call');
+    assert.match(output.instruction, /必要があれば担当者から折り返す/);
+});


### PR DESCRIPTION
## Summary
- Block human handoff for sales, recruiting proposals, solicitation, advertising, and similar calls even if the model emits transfer_to_human.
- Keep representative requests eligible only for non-sales human support cases.
- Tell the caller that the proposal will be reported and a person will call back only if needed; finish without callback details unless explicitly requested.

## Evidence
- Call CA8a41e6644deb45c23169e1597cea4750 was classified as 営業提案, but logs show handoff.start.succeeded with destination=general at 2026-07-15 19:28:59 JST.
- npm test: 61 tests, 0 failures.