### PR TITLE
Return rejected handoffs to call center

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ import {
     summarizeHandoffWhisper,
     shouldAutoHandoffGeneral,
     isNonHandoffBusinessCall,
+    isHandoffCallConnected,
     updateTwilioCallTwiml
 } from './lib/handoff.js';
 import { NotificationOutbox } from './lib/notification-outbox.js';
@@ -647,15 +648,16 @@ fastify.post('/handoff/dial-status', async (request, reply) => {
     if (!HANDOFF_CONFIG.enabled) return reply.code(404).send({ error: 'handoff_disabled' });
     if (!isValidTwilioWebhook({ request })) return reply.code(403).send('Forbidden');
 
-    const connected = request.body?.DialCallStatus === 'completed';
+    let context = null;
+    try {
+        context = await handoffContextStore.get(callSid);
+    } catch (error) {
+        console.error('Failed to load handoff dial context:', error.message);
+    }
+    const whisperRejected = context?.status === 'whisper_rejected';
+    const connected = isHandoffCallConnected(request.body?.DialCallStatus, context);
     let fallbackTwiml = '';
     if (!connected) {
-        let context = null;
-        try {
-            context = await handoffContextStore.get(callSid);
-        } catch (error) {
-            console.error('Failed to load handoff fallback context:', error.message);
-        }
         const text = [
             '担当者への転送が成立しませんでした。',
             context?.summary ? `受付内容: ${context.summary}` : '受付内容は管理画面で確認してください。',
@@ -694,7 +696,11 @@ fastify.post('/handoff/dial-status', async (request, reply) => {
     auditLog('handoff.dial.completed', {
         actor: 'twilio',
         target: callSid,
-        metadata: { dialCallStatus: request.body?.DialCallStatus || '', connected }
+        metadata: {
+            dialCallStatus: request.body?.DialCallStatus || '',
+            connected,
+            whisperRejected
+        }
     });
     return sendTwiml(reply, connected ? buildDialStatusTwiml({ connected }) : fallbackTwiml);
 });

--- a/lib/handoff.js
+++ b/lib/handoff.js
@@ -156,6 +156,11 @@ export function shouldAllowHumanHandoff(turns = [], destination = 'general') {
         : shouldAutoHandoffGeneral(turns);
 }
 
+export function isHandoffCallConnected(dialCallStatus, context = {}) {
+    return String(dialCallStatus || '').toLowerCase() === 'completed'
+        && context?.status !== 'whisper_rejected';
+}
+
 export function findTransferToHumanToolCalls(event) {
     const outputs = Array.isArray(event?.response?.output) ? event.response.output : [];
 

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -6,6 +6,7 @@ import {
     buildTransferToHumanTool,
     findTransferToHumanToolCalls,
     HandoffContextStore,
+    isHandoffCallConnected,
     isNonHandoffBusinessCall,
     isContractRequest,
     shouldAutoHandoffGeneral,
@@ -116,6 +117,12 @@ test('handoff whisper summary is one compact sentence', () => {
     assert.match(summary, /^用件は/);
     assert.doesNotMatch(summary, /。/);
     assert.ok(summary.length <= 180);
+});
+
+test('handoff rejection forces parent Dial fallback even if Twilio reports completed', () => {
+    assert.equal(isHandoffCallConnected('completed', { status: 'whisper_rejected' }), false);
+    assert.equal(isHandoffCallConnected('completed', { status: 'whisper_accepted' }), true);
+    assert.equal(isHandoffCallConnected('no-answer', { status: 'requested' }), false);
 });
 
 test('handoff policy blocks recruiting sales proposals but keeps contract requests eligible', () => {


### PR DESCRIPTION
## Summary
- Treat whisper rejection as non-connected even if Twilio reports the child leg completed.
- Ensure the parent call receives the existing call-center fallback TwiML after digit 2.
- Add unit coverage for the rejection state.

## Verification
- npm test: 67 tests, 0 failures.