### PR TITLE
Route non-sales non-urgent calls to callback workflow

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,6 +39,7 @@ import {
     summarizeHandoffWhisper,
     shouldAutoHandoffGeneral,
     isNonHandoffBusinessCall,
+    isSalesBusinessCall,
     isHandoffCallConnected,
     updateTwilioCallTwiml
 } from './lib/handoff.js';
@@ -80,7 +81,7 @@ const DEFAULT_SYSTEM_MESSAGE = [
     '氏名は聞こえた読みをそのままカタカナで確認してください。一般的な漢字名へ勝手に変換しないでください。',
     '氏名が少しでも不確かな場合は「お名前の読みをカタカナで確認させてください」と聞き返してください。',
     '会話を勝手に終了せず、必要に応じて担当者へ引き継ぐ旨を伝え、受付完了時は終話ルールに従って案内してください。',
-    '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。営業・採用提案は担当者へ報告し、必要があれば担当者から折り返すと案内してください。そのため、折り返し希望の有無にかかわらず、必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証して記録してください。電話番号を確認できるまでfinish_receptionを呼び出さないでください。終話時のcallback_requiredは、発信者が折り返しを希望した場合だけtrueにしてください。',
+    '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。営業・採用提案は担当者へ報告し、必要があれば担当者から折り返すと案内してください。営業では折り返し希望の有無にかかわらず必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証して記録してください。発信者が明確に折り返しを希望しない限り、営業のcallback_requiredはfalseにしてください。イベント・一般相談・緊急性のない代表者への取次ぎなど営業ではない相談は、必要時の連絡先電話番号を聞いて検証し、担当者から改めて折り返すためcallback_required=trueにしてください。電話番号を確認できるまでfinish_receptionを呼び出さないでください。',
     '受託案件、開発・制作、業務委託、見積相談など仕事の依頼で人間対応が必要な場合は、transfer_to_humanをdestination="contract"で使用してください。',
     'それ以外で、急ぎ・緊急の人間対応が必要な場合だけtransfer_to_humanをdestination="general"で使用してください。緊急性のない相談、イベント、一般案内、代表者への取次ぎ依頼はコールセンターでヒアリングして終話してください。',
     'まだ社名や業務ナレッジが未設定のため、断定できない内容は「確認して折り返します」と案内してください。'
@@ -1009,6 +1010,7 @@ fastify.register(async (fastify) => {
 
         const handleToolCalls = (event) => {
             const nonHandoffBusinessCall = isNonHandoffBusinessCall(session.turns);
+            const requireBusinessCallback = nonHandoffBusinessCall && !isSalesBusinessCall(session.turns);
             const result = handleRealtimeToolCalls({
                 event,
                 state: session,
@@ -1017,6 +1019,7 @@ fastify.register(async (fastify) => {
                     ...HANDOFF_CONFIG,
                     blockNonHandoffBusiness: nonHandoffBusinessCall,
                     requireCallbackContact: nonHandoffBusinessCall,
+                    requireBusinessCallback,
                     enforceRoutingPolicy: true
                 },
                 onPhoneValidation: (metadata) => auditLog('callback_phone.validation', {

--- a/lib/handoff.js
+++ b/lib/handoff.js
@@ -14,12 +14,15 @@ const GENERAL_HANDOFF_PATTERNS = [
 const CONTRACT_REQUEST_PATTERNS = [
     /(受託|開発|制作|業務委託|見積|発注|実装|システムを作|案件|依頼)/
 ];
-const NON_HANDOFF_BUSINESS_PATTERNS = [
+const SALES_BUSINESS_PATTERNS = [
     /(営業|営業電話|勧誘|広告|売り込み|テレアポ|アポイント)/,
     /(紹介料|アサイン|採用サポート|採用支援|人材紹介)/,
     /(採用|人材|エンジニア)[^。！？\n]{0,60}(紹介|アサイン|採用サポート|採用支援|紹介料|ご提案)/,
     /(?:弊社|当社)[^。！？\n]{0,40}(ご提案|ご紹介|サービス|システム|営業)/,
-    /(従来より|通常より|他社より)[^。！？\n]{0,20}(安|抑|割引|低)/,
+    /(従来より|通常より|他社より)[^。！？\n]{0,20}(安|抑|割引|低)/
+];
+const NON_HANDOFF_BUSINESS_PATTERNS = [
+    ...SALES_BUSINESS_PATTERNS,
     /(イベント|交流会|勉強会|セミナー|カンファレンス)[^。！？\n]{0,80}(開催|企画|誘い|相談|集め|参加|会場)/,
     /(代表|責任者)[^。！？\n]{0,40}(いらっしゃる|お話|話したい|相談|つな|繋)/
 ];
@@ -113,7 +116,8 @@ export function appendHandoffInstructions(instructions, config = {}) {
             '受託案件、開発・制作、業務委託、見積相談など仕事の依頼は destination="contract" を指定してください。',
             '料金不足、支払・請求・入金・返金の相違、既存取引への苦情、明確に急ぎ・緊急の人間対応は destination="general" を指定し、氏名や折り返し番号を先に聞かず、すぐに転送してください。',
             '代表・責任者への相談だけでは転送しません。営業・採用・勧誘・広告、イベント、一般案内、緊急性のない相談はコールセンターで受付してください。',
-            '採用応募・採用関連、営業・勧誘・広告、一般的な案内は転送せず、AIで内容を受付・記録してください。担当者へ報告し、必要があれば担当者から折り返すと案内してください。折り返し希望の有無にかかわらず、必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証してからfinish_receptionを呼び出してください。発信者が明確に折り返しを希望しない限り、callback_required=falseで終話してください。',
+            '営業・採用勧誘・広告は転送せず、AIで内容を受付・記録してください。担当者へ報告し、必要があれば担当者から折り返すと案内してください。必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証してからfinish_receptionを呼び出してください。営業の場合、発信者が明確に折り返しを希望しない限りcallback_required=falseで終話してください。',
+            '営業ではないイベント・一般相談・代表者への取次ぎなど緊急性のない相談は転送せず、コールセンターで受付してください。必要時の連絡先電話番号を聞き、担当者から改めて折り返すためcallback_required=trueで終話してください。',
             '転送ツール実行後は、電話を切らずに担当者へつなぐ案内を短く行ってください。'
         ].join('\n')
     ].join('\n\n');
@@ -148,6 +152,17 @@ export function isNonHandoffBusinessCall(turns = []) {
 
     if (shouldAutoHandoffGeneral(turns) || isContractRequest(turns)) return false;
     return NON_HANDOFF_BUSINESS_PATTERNS.some((pattern) => pattern.test(recentUserText));
+}
+
+export function isSalesBusinessCall(turns = []) {
+    const recentUserText = turns
+        .filter((turn) => turn?.role === 'user')
+        .slice(-8)
+        .map((turn) => normalizeText(turn.text))
+        .join(' ');
+
+    if (shouldAutoHandoffGeneral(turns) || isContractRequest(turns)) return false;
+    return SALES_BUSINESS_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
 export function shouldAllowHumanHandoff(turns = [], destination = 'general') {

--- a/lib/realtime-tool-flow.js
+++ b/lib/realtime-tool-flow.js
@@ -115,6 +115,7 @@ export function handleRealtimeToolCalls({
     const handoffToolCalls = findTransferToHumanToolCalls(event);
     if (handoffToolCalls.length > 0) {
         const handoffBlockedByBusinessPolicy = handoffConfig.blockNonHandoffBusiness === true;
+        const businessCallbackRequired = handoffConfig.requireBusinessCallback === true;
         if (handoffBlockedByBusinessPolicy || !handoffConfig.enabled || handoffConfig.numbers.length === 0) {
             for (const toolCall of handoffToolCalls) {
                 outputs.push(functionCallOutputItem(toolCall.callId, {
@@ -123,7 +124,9 @@ export function handleRealtimeToolCalls({
                         ? 'non_handoff_business_call'
                         : 'handoff_unavailable',
                     instruction: handoffBlockedByBusinessPolicy
-                        ? '営業・採用・勧誘・広告の受付なので電話転送は行いません。内容を担当者へ報告し、必要があれば担当者から折り返すと案内してください。明確な折り返し希望がなければcallback_required=falseのfinish_receptionで受付を完了してください。'
+                        ? businessCallbackRequired
+                            ? '緊急性のない相談なので電話転送は行いません。内容をコールセンターで受付し、必要時の連絡先電話番号を聞いてvalidate_callback_phoneで検証してください。担当者から改めて折り返すためcallback_required=trueのfinish_receptionで受付を完了してください。'
+                            : '営業・採用・勧誘・広告の受付なので電話転送は行いません。内容を担当者へ報告し、必要があれば担当者から折り返すと案内してください。必要時の連絡先電話番号を聞いてvalidate_callback_phoneで検証し、明確な折り返し希望がなければcallback_required=falseのfinish_receptionで受付を完了してください。'
                         : '担当者への転送機能が現在利用できません。転送できない旨を丁寧に案内し、受付内容を記録してください。'
                 }));
             }
@@ -168,7 +171,10 @@ export function handleRealtimeToolCalls({
     const finishToolCalls = findFinishReceptionToolCalls(event);
     if (finishToolCalls.length > 0) {
         for (const toolCall of finishToolCalls) {
-            const callbackContactRequired = toolCall.callbackRequired || handoffConfig.requireCallbackContact === true;
+            const businessCallbackRequired = handoffConfig.requireBusinessCallback === true;
+            const callbackContactRequired = toolCall.callbackRequired
+                || handoffConfig.requireCallbackContact === true
+                || businessCallbackRequired;
             if (callbackContactRequired && !toolState.callbackPhone?.valid) {
                 outputs.push(functionCallOutputItem(toolCall.callId, {
                     ok: false,
@@ -177,7 +183,18 @@ export function handleRealtimeToolCalls({
                         : 'business_callback_contact_not_validated',
                     instruction: toolCall.callbackRequired
                         ? '折り返しが必要です。finish_receptionの前に折り返し先電話番号を聞き、validate_callback_phoneで有効判定を受けてから顧客に確認してください。'
-                        : '営業・採用提案の受付を完了する前に、必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで有効判定を受けてください。折り返し希望がなければcallback_required=falseのままfinish_receptionを再実行してください。'
+                        : businessCallbackRequired
+                            ? '緊急性のない相談の受付を完了する前に、折り返し先電話番号を一つ聞き、validate_callback_phoneで有効判定を受けてください。担当者から改めて折り返すためcallback_required=trueでfinish_receptionを再実行してください。'
+                            : '営業・採用提案の受付を完了する前に、必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで有効判定を受けてください。折り返し希望がなければcallback_required=falseのままfinish_receptionを再実行してください。'
+                }));
+                continue;
+            }
+
+            if (businessCallbackRequired && !toolCall.callbackRequired) {
+                outputs.push(functionCallOutputItem(toolCall.callId, {
+                    ok: false,
+                    reason: 'business_callback_required',
+                    instruction: '営業ではない緊急性のない相談なので、担当者から改めて折り返します。finish_receptionをcallback_required=trueで再実行してください。'
                 }));
                 continue;
             }

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -8,6 +8,7 @@ import {
     HandoffContextStore,
     isHandoffCallConnected,
     isNonHandoffBusinessCall,
+    isSalesBusinessCall,
     isContractRequest,
     shouldAutoHandoffGeneral,
     shouldAllowHumanHandoff,
@@ -126,11 +127,16 @@ test('handoff rejection forces parent Dial fallback even if Twilio reports compl
 });
 
 test('handoff policy blocks recruiting sales proposals but keeps contract requests eligible', () => {
-    assert.equal(isNonHandoffBusinessCall([
+    const salesTurns = [
         { role: 'user', text: '弊社でエンジニアの採用サポートをしており、紹介料を抑えてアサインできます。' }
-    ]), true);
+    ];
+    assert.equal(isNonHandoffBusinessCall(salesTurns), true);
+    assert.equal(isSalesBusinessCall(salesTurns), true);
     assert.equal(isNonHandoffBusinessCall([
         { role: 'user', text: 'システム開発を依頼したいので、見積もりを相談したいです。' }
+    ]), false);
+    assert.equal(isSalesBusinessCall([
+        { role: 'user', text: 'エンジニアを集めたイベントを開催したい相談です。' }
     ]), false);
 });
 

--- a/test/realtime-tool-flow.test.js
+++ b/test/realtime-tool-flow.test.js
@@ -225,6 +225,54 @@ test('Realtime tool flow requires a contact number before closing a business cal
     assert.deepEqual(result.callEndRequests, []);
 });
 
+test('Realtime tool flow requires callback_required for non-sales non-urgent business calls', () => {
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('finish_reception', 'finish_event_1', {
+            reason: 'イベント相談の受付完了',
+            callback_required: false
+        }),
+        state: {
+            callbackPhone: {
+                valid: true,
+                normalizedPhoneNumber: '09012345678'
+            }
+        },
+        callEndConfig: buildCallEndConfig(),
+        handoffConfig: {
+            requireCallbackContact: true,
+            requireBusinessCallback: true
+        }
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.equal(result.handled, true);
+    assert.equal(output.ok, false);
+    assert.equal(output.reason, 'business_callback_required');
+    assert.deepEqual(result.callEndRequests, []);
+});
+
+test('Realtime tool flow allows sales call without callback when contact is validated', () => {
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('finish_reception', 'finish_sales_2', {
+            reason: '営業提案の報告完了',
+            callback_required: false
+        }),
+        state: {
+            callbackPhone: {
+                valid: true,
+                normalizedPhoneNumber: '09012345678'
+            }
+        },
+        callEndConfig: buildCallEndConfig(),
+        handoffConfig: { requireCallbackContact: true }
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.equal(output.ok, true);
+    assert.equal(output.callback_required, false);
+    assert.equal(result.callEndRequests.length, 1);
+});
+
 test('Realtime tool flow blocks non-urgent general handoff', () => {
     const result = handleRealtimeToolCalls({
         event: toolEvent('transfer_to_human', 'handoff_event_1', {


### PR DESCRIPTION
## Summary

- distinguish sales callbacks from non-sales non-urgent business callbacks
- keep event, general consultation, and non-urgent representative requests in the call center
- require a validated callback number and callback_required=true for non-sales non-urgent cases
- keep sales callback_required=false unless the caller explicitly requests a callback
- preserve the one-sentence handoff whisper and digit 2 return-to-call-center flow

## Root cause

The event consultation was classified as a general human handoff because the model could invoke transfer_to_human for a representative-style request, while the business policy only distinguished sales from other calls. The runtime now applies an explicit routing policy and server-side finish_reception guard.

## Validation

- npm test
- 69 tests passed
- git diff --check

## Deployment

After CI passes, merge to develop and deploy the production Cloud Run service in cor-jp-web.