### PR TITLE
Harden non-contract call routing

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,7 +37,9 @@ import {
     HandoffContextStore,
     summarizeHandoffTurns,
     summarizeHandoffWhisper,
+    isComplaintCall,
     isContractRequest,
+    isEmergencyCall,
     isNonHandoffBusinessCall,
     isSalesBusinessCall,
     isHandoffCallConnected,
@@ -91,8 +93,10 @@ const DEFAULT_SYSTEM_MESSAGE = [
     '支払い差額、正当な苦情、強い不満、暴言、脅し、威圧など判断の難しい用件は、内部カテゴリを説明せず、口論や説教をせずにAI受付を継続してください。システムが必要に応じて高精度対応モードへ切り替えます。',
     '苦情・クレーム・支払いトラブルは、苦情だけを理由に担当者へ即時転送してはいけません。高精度対応モードで事実関係、相手の希望、緊急性を整理し、人間の判断・謝罪・補償判断・事実確認が必要な場合だけ担当者への転送を検討してください。',
     '脅迫・暴言・威圧などは人間へ自動転送せず、AIコールセンターとして落ち着いて対応してください。反論や説教をせず、対応可能な範囲を示し、攻撃的な発言が続く場合は必要事項を最小限確認して丁寧に終話してください。',
+    '生命・身体に関わる緊急事態、火災、救急車が必要な状況などは担当者へ転送せず、直ちに危険がある場合は110または119へ連絡するよう案内してください。',
     '会話を勝手に終了せず、必要に応じて担当者へ引き継ぐ旨を伝え、受付完了時は終話ルールに従って案内してください。',
-    '採用応募・採用関連、営業・勧誘・広告、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。営業・採用提案は担当者へ報告し、必要があれば担当者から折り返すと案内してください。営業では折り返し希望の有無にかかわらず必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証して記録してください。発信者が明確に折り返しを希望しない限り、営業のcallback_requiredはfalseにしてください。イベント・一般相談・緊急性のない代表者への取次ぎなど営業ではない相談は、必要時の連絡先電話番号を聞いて検証し、担当者から改めて折り返すためcallback_required=trueにしてください。電話番号を確認できるまでfinish_receptionを呼び出さないでください。',
+    '採用応募・採用選考、営業・勧誘・広告、業務提携・代理店・取材・協賛、一般的な案内はAIで用件を受け付け、担当者へ自動転送しないでください。営業・採用提案は担当者へ報告し、必要があれば担当者から折り返すと案内してください。営業では折り返し希望の有無にかかわらず必要時の連絡先電話番号を一つ聞き、validate_callback_phoneで検証して記録してください。発信者が明確に折り返しを希望しない限り、営業のcallback_requiredはfalseにしてください。採用応募・採用選考、イベント、業務提携、代理店、取材、協賛、一般相談、緊急性のない代表者への取次ぎは、連絡先電話番号を聞いて検証し、担当者から改めて折り返すためcallback_required=trueにしてください。営業時間や使い方など単純な案内は、確認できる範囲で回答し、回答できない場合だけ折り返し受付にしてください。電話番号を確認できるまでfinish_receptionを呼び出さないでください。',
+    '契約解除・契約違反、法務・弁護士・訴訟、個人情報漏えい・不正アクセス・セキュリティ事故などは、通常受付で断定せず、高精度対応モードへ切り替えて事実関係と緊急性を整理してください。',
     '受託案件、開発・制作、業務委託、見積相談など仕事の依頼で人間対応が必要な場合は、transfer_to_humanをdestination="contract"で使用してください。',
     'それ以外で、急ぎ・緊急の人間対応が必要な場合だけtransfer_to_humanをdestination="general"で使用してください。緊急性のない相談、イベント、一般案内、代表者への取次ぎ依頼はコールセンターでヒアリングして終話してください。',
     'まだ社名や業務ナレッジが未設定のため、断定できない内容は「確認して折り返します」と案内してください。'
@@ -1033,7 +1037,9 @@ fastify.register(async (fastify) => {
 
         const handleToolCalls = (event) => {
             const nonHandoffBusinessCall = isNonHandoffBusinessCall(session.turns);
-            const requireBusinessCallback = nonHandoffBusinessCall && !isSalesBusinessCall(session.turns);
+            const complexSupportCallbackRequired = isComplaintCall(session.turns);
+            const requireBusinessCallback = (nonHandoffBusinessCall && !isSalesBusinessCall(session.turns))
+                || complexSupportCallbackRequired;
             const result = handleRealtimeToolCalls({
                 event,
                 state: session,
@@ -1041,13 +1047,13 @@ fastify.register(async (fastify) => {
                 handoffConfig: {
                     ...HANDOFF_CONFIG,
                     blockNonHandoffBusiness: nonHandoffBusinessCall,
-                    requireCallbackContact: nonHandoffBusinessCall,
+                    requireCallbackContact: nonHandoffBusinessCall || complexSupportCallbackRequired,
                     requireBusinessCallback,
                     enforceRoutingPolicy: true
                 },
                 allowComplexComplaintHandoff: activeRealtimeModel === COMPLEX_REALTIME_MODEL
                     || session.modelEscalation?.status === 'active'
-                    && session.modelEscalation?.category === 'complaint',
+                    && ['complaint', 'complex_support'].includes(session.modelEscalation?.category),
                 onPhoneValidation: (metadata) => auditLog('callback_phone.validation', {
                     actor: 'realtime',
                     target: session.callSid || sessionId,
@@ -1328,6 +1334,7 @@ fastify.register(async (fastify) => {
                         if (
                             HANDOFF_CONFIG.enabled
                             && urgentHumanSupport
+                            && !isEmergencyCall(session.turns)
                             && !session.handoff?.started
                             && !session.handoff?.starting
                             && !isNonHandoffBusinessCall(session.turns)

--- a/lib/handoff.js
+++ b/lib/handoff.js
@@ -5,12 +5,24 @@ const CALL_SID_PATTERN = /^CA[a-fA-F0-9]{32}$/;
 const HANDOFF_DESTINATIONS = Object.freeze(['contract', 'general']);
 const normalizeText = (value) => String(value || '').replace(/\s+/g, ' ').trim();
 const PAYMENT_DISPUTE_PATTERNS = [
-    /(料金|金額|支払|支払い|払った|請求|入金|返金|取引|委託費)[^。！？\n]{0,40}(不足|足り|差額|違|間違|未払|確認|相談|返金)/,
+    /(料金|金額|支払|支払い|払った|請求|入金|返金|取引|委託費|報酬)[^。！？\n]{0,40}(不足|足り|差額|違|間違|未払|遅れ|遅延|二重|トラブル|確認|相談|質問|返金)/,
     /(不足|足り|差額|違|間違)[^。！？\n]{0,24}(料金|金額|支払|支払い|請求|入金|取引)/
 ];
 const COMPLAINT_PATTERNS = [
     /(苦情|クレーム|強い不満|納得できない|謝罪|補償|返金|説明してほしい|対応が悪い|話が違う|契約違反)/,
     /(困っている|改善してほしい|責任を取|責任を持|抗議|申し立て)/
+];
+const COMPLEX_SUPPORT_PATTERNS = [
+    /(契約|契約書)[^。！？\n]{0,40}(解除|解約|違反|損害|賠償|法務|弁護士|訴訟|法的措置)/,
+    /(個人情報|情報漏えい|情報漏洩|不正アクセス|乗っ取り|セキュリティ)[^。！？\n]{0,40}(漏|事故|被害|対応|確認|相談|報告)/,
+    /(個人情報|情報漏えい|情報漏洩|不正アクセス|アカウント乗っ取り|アカウントの乗っ取り|セキュリティ事故|セキュリティ被害|情報が漏れた|情報が漏れている)/,
+    /(弁護士|訴訟|訴える|法的措置|損害賠償|消費者センター|警察)[^。！？\n]{0,40}(相談|連絡|対応|伝|話|確認)?/,
+    /(パワハラ|セクハラ|ハラスメント)[^。！？\n]{0,40}(相談|被害|対応|報告|確認)/,
+    /(重大|深刻)[^。！？\n]{0,24}(事故|トラブル|問題|被害|漏えい|漏洩)/
+];
+const EMERGENCY_PATTERNS = [
+    /(救急車|消防車|火事|火災|119|110)/,
+    /(意識がない|意識がありません|意識不明|呼吸ができない|出血が止まらない|倒れた|けがをした|怪我をした|今危険|身の危険|襲われている)/
 ];
 const CUSTOMER_HARASSMENT_PATTERNS = [
     /(カスタマーハラスメント|カスハラ|暴言|罵倒|怒鳴|恫喝|脅迫|脅す|威圧|嫌がらせ|迷惑行為)/,
@@ -18,7 +30,7 @@ const CUSTOMER_HARASSMENT_PATTERNS = [
     /(土下座|責任者を出せ|責任取れ|ふざけるな|いい加減にしろ|何度言わせる|話にならない)/
 ];
 const GENERAL_HANDOFF_PATTERNS = [
-    /(急ぎ|急な|至急|緊急|今すぐ|すぐに|今日中|本日中|早急|障害|止まっている|使えない)/,
+    /(急ぎ|急な|至急|緊急|今すぐ|すぐに|今日中|本日中|早急|障害(?!者)|止まっている|使えない)/,
     /(代表|責任者|担当者)[^。！？\n]{0,30}(急ぎ|至急|緊急|今すぐ|すぐに|今日中|本日中|早急)/
 ];
 const CONTRACT_REQUEST_PATTERNS = [
@@ -27,16 +39,32 @@ const CONTRACT_REQUEST_PATTERNS = [
     /(仕事|案件|業務)[^。！？\n]{0,30}(依頼|お願い|相談|発注|見積|受託|業務委託)/
 ];
 const SALES_BUSINESS_PATTERNS = [
-    /(営業|営業電話|勧誘|広告|売り込み|テレアポ|アポイント)/,
+    /(営業(?!時間|日|所|中|部)|営業電話|勧誘|広告|売り込み|テレアポ|アポイント)/,
     /(紹介料|アサイン|採用サポート|採用支援|人材紹介)/,
     /(採用|人材|エンジニア)[^。！？\n]{0,60}(紹介|アサイン|採用サポート|採用支援|紹介料|ご提案)/,
     /(?:弊社|当社)[^。！？\n]{0,40}(ご提案|ご紹介|サービス|システム|営業)/,
     /(従来より|通常より|他社より)[^。！？\n]{0,20}(安|抑|割引|低)/
 ];
+const RECRUITING_APPLICANT_PATTERNS = [
+    /(採用応募|応募者|応募|エントリー|面接|履歴書|職務経歴書)[^。！？\n]{0,40}(したい|した|について|相談|確認|送|提出|応募)?/,
+    /(仕事|働|入社)[^。！？\n]{0,30}(応募|面接|採用|選考)/
+];
+const PARTNERSHIP_AND_MEDIA_PATTERNS = [
+    /(業務提携|提携|協業|パートナー|代理店|販売店|取材|掲載|メディア|講演|協賛)[^。！？\n]{0,50}(相談|依頼|お願い|提案|希望|したい|なりたい|について|お話)?/,
+    /(当社|弊社)[^。！？\n]{0,60}(代理店|提携|協業|取材|掲載|協賛)[^。！？\n]{0,30}(相談|提案|お願い|希望|したい|なりたい)?/
+];
+const EVENT_BUSINESS_PATTERNS = [
+    /(イベント|交流会|勉強会|セミナー|カンファレンス)[^。！？\n]{0,80}(開催|企画|誘い|相談|集め|参加|会場)/
+];
+const REPRESENTATIVE_REQUEST_PATTERNS = [
+    /(代表|責任者)[^。！？\n]{0,40}(いらっしゃる|お話|話したい|相談|つな|繋)/
+];
 const NON_HANDOFF_BUSINESS_PATTERNS = [
     ...SALES_BUSINESS_PATTERNS,
-    /(イベント|交流会|勉強会|セミナー|カンファレンス)[^。！？\n]{0,80}(開催|企画|誘い|相談|集め|参加|会場)/,
-    /(代表|責任者)[^。！？\n]{0,40}(いらっしゃる|お話|話したい|相談|つな|繋)/
+    ...RECRUITING_APPLICANT_PATTERNS,
+    ...PARTNERSHIP_AND_MEDIA_PATTERNS,
+    ...EVENT_BUSINESS_PATTERNS,
+    ...REPRESENTATIVE_REQUEST_PATTERNS
 ];
 
 export function normalizeHandoffDestination(value) {
@@ -158,7 +186,18 @@ function recentUserText(turns = [], maxTurns = 8) {
 export function isComplaintCall(turns = []) {
     const text = recentUserText(turns);
     return PAYMENT_DISPUTE_PATTERNS.some((pattern) => pattern.test(text))
-        || COMPLAINT_PATTERNS.some((pattern) => pattern.test(text));
+        || COMPLAINT_PATTERNS.some((pattern) => pattern.test(text))
+        || COMPLEX_SUPPORT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isComplexSupportCall(turns = []) {
+    const text = recentUserText(turns);
+    return COMPLEX_SUPPORT_PATTERNS.some((pattern) => pattern.test(text));
+}
+
+export function isEmergencyCall(turns = []) {
+    const text = recentUserText(turns);
+    return EMERGENCY_PATTERNS.some((pattern) => pattern.test(text));
 }
 
 export function isCustomerHarassmentCall(turns = []) {
@@ -178,6 +217,7 @@ export function isContractRequest(turns = []) {
         .map((turn) => normalizeText(turn.text))
         .join(' ');
 
+    if (PARTNERSHIP_AND_MEDIA_PATTERNS.some((pattern) => pattern.test(recentUserText))) return false;
     return CONTRACT_REQUEST_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
@@ -188,8 +228,17 @@ export function isNonHandoffBusinessCall(turns = []) {
         .map((turn) => normalizeText(turn.text))
         .join(' ');
 
-    if (shouldAutoHandoffGeneral(turns) || isComplaintCall(turns) || isCustomerHarassmentCall(turns) || isContractRequest(turns)) return false;
-    return NON_HANDOFF_BUSINESS_PATTERNS.some((pattern) => pattern.test(recentUserText));
+    if (isEmergencyCall(turns) || isComplaintCall(turns) || isCustomerHarassmentCall(turns) || isContractRequest(turns)) return false;
+
+    const specificBusinessPatterns = [
+        ...SALES_BUSINESS_PATTERNS,
+        ...RECRUITING_APPLICANT_PATTERNS,
+        ...PARTNERSHIP_AND_MEDIA_PATTERNS,
+        ...EVENT_BUSINESS_PATTERNS
+    ];
+    if (specificBusinessPatterns.some((pattern) => pattern.test(recentUserText))) return true;
+    if (shouldAutoHandoffGeneral(turns)) return false;
+    return REPRESENTATIVE_REQUEST_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
 export function isSalesBusinessCall(turns = []) {
@@ -199,17 +248,19 @@ export function isSalesBusinessCall(turns = []) {
         .map((turn) => normalizeText(turn.text))
         .join(' ');
 
-    if (shouldAutoHandoffGeneral(turns) || isComplaintCall(turns) || isCustomerHarassmentCall(turns) || isContractRequest(turns)) return false;
+    if (isEmergencyCall(turns) || isComplaintCall(turns) || isCustomerHarassmentCall(turns) || isContractRequest(turns)) return false;
     return SALES_BUSINESS_PATTERNS.some((pattern) => pattern.test(recentUserText));
 }
 
 export function shouldAllowHumanHandoff(turns = [], destination = 'general') {
+    if (isEmergencyCall(turns) || isNonHandoffBusinessCall(turns)) return false;
     return String(destination || '').trim().toLowerCase() === 'contract'
         ? isContractRequest(turns)
         : shouldAutoHandoffGeneral(turns);
 }
 
 export function resolveHandoffDestination(turns = [], destination = 'general') {
+    if (isEmergencyCall(turns)) return 'general';
     if (shouldAutoHandoffGeneral(turns) || isComplaintCall(turns) || isCustomerHarassmentCall(turns)) return 'general';
     return normalizeHandoffDestination(destination);
 }

--- a/lib/realtime-escalation.js
+++ b/lib/realtime-escalation.js
@@ -1,4 +1,4 @@
-import { isComplaintCall, isCustomerHarassmentCall } from './handoff.js';
+import { isComplaintCall, isComplexSupportCall, isCustomerHarassmentCall } from './handoff.js';
 
 export const STANDARD_REALTIME_MODEL = 'gpt-realtime-2.1-mini';
 export const COMPLEX_REALTIME_MODEL = 'gpt-realtime-2.1';
@@ -10,6 +10,15 @@ export function classifyRealtimeConversation(turns = []) {
             category: 'customer_harassment',
             targetModel: COMPLEX_REALTIME_MODEL,
             humanTransferAllowed: false
+        };
+    }
+
+    if (isComplexSupportCall(turns)) {
+        return {
+            tier: 'complex_complaint',
+            category: 'complex_support',
+            targetModel: COMPLEX_REALTIME_MODEL,
+            humanTransferAllowed: true
         };
     }
 
@@ -40,8 +49,8 @@ export function buildComplexRealtimeInstructions(category) {
     }
 
     return [
-        'これは苦情・クレーム・支払いトラブルなど、判断の精度が必要な相談です。AI受付を継続し、事実関係、相手の希望、緊急性を一つずつ確認してください。',
-        '苦情や支払いトラブルだけを理由に担当者へ転送してはいけません。人間による判断・謝罪・補償判断・事実確認が必要か、または発信者が明確に担当者対応を求めているかを整理してください。',
+        'これは苦情・クレーム・支払いトラブル・契約紛争・法務相談・情報セキュリティ事故など、判断の精度が必要な相談です。AI受付を継続し、事実関係、相手の希望、緊急性を一つずつ確認してください。',
+        '苦情や支払いトラブルだけを理由に担当者へ転送してはいけません。人間による判断・謝罪・補償判断・事実確認が必要か、または発信者が明確に担当者対応を求めているかを整理してください。法務・個人情報・セキュリティに関する相談は、事実を断定せず、必要に応じてgeneralへ転送してください。',
         '人間の判断が必要だと判断した場合だけtransfer_to_humanをdestination="general"で使用してください。発信者には内部の分類や判断理由を説明しないでください。'
     ].join('\n');
 }

--- a/lib/realtime-tool-flow.js
+++ b/lib/realtime-tool-flow.js
@@ -11,6 +11,7 @@ import {
     findTransferToHumanToolCalls,
     isComplaintCall,
     isCustomerHarassmentCall,
+    isEmergencyCall,
     resolveHandoffDestination,
     shouldAllowHumanHandoff
 } from './handoff.js';
@@ -140,23 +141,28 @@ export function handleRealtimeToolCalls({
         } else {
             for (const toolCall of handoffToolCalls) {
                 const destination = resolveHandoffDestination(toolState.turns || [], toolCall.destination);
+                const emergencyCall = isEmergencyCall(toolState.turns || []);
                 const customerHarassmentBlocked = isCustomerHarassmentCall(toolState.turns || [])
                     && destination === 'general';
                 const complexComplaintHandoffAllowed = allowComplexComplaintHandoff
                     && destination === 'general'
                     && isComplaintCall(toolState.turns || [])
                     && !customerHarassmentBlocked;
-                if (customerHarassmentBlocked || (handoffConfig.enforceRoutingPolicy
+                if (emergencyCall || customerHarassmentBlocked || (handoffConfig.enforceRoutingPolicy
                     && !shouldAllowHumanHandoff(toolState.turns || [], destination)
                     && !complexComplaintHandoffAllowed)) {
                     outputs.push(functionCallOutputItem(toolCall.callId, {
                         ok: false,
-                        reason: customerHarassmentBlocked
+                        reason: emergencyCall
+                            ? 'emergency_services'
+                            : customerHarassmentBlocked
                             ? 'customer_harassment_ai_handling'
                             : destination === 'contract'
                             ? 'contract_request_not_detected'
                             : 'non_urgent_general_handoff',
-                        instruction: customerHarassmentBlocked
+                        instruction: emergencyCall
+                            ? '生命や身体に関わる緊急事態の可能性があるため、電話転送は行いません。顧客には、直ちに緊急の場合は110または119へ連絡するよう短く案内し、会社の受付で対応できる範囲を説明してください。'
+                            : customerHarassmentBlocked
                             ? '人間への転送は行いません。暴言や威圧には反論せず、落ち着いた言葉で対応可能な範囲を案内し、必要な事実を最小限確認してください。攻撃的な発言が続く場合は丁寧に終話してください。'
                             : destination === 'contract'
                             ? '転送対象の仕事の依頼として確認できないため、電話転送は行いません。顧客には判定理由を説明せず、内容を受付して確認後に折り返す案内をしてください。'

--- a/test/handoff.test.js
+++ b/test/handoff.test.js
@@ -12,7 +12,9 @@ import {
     isSalesBusinessCall,
     isContractRequest,
     isComplaintCall,
+    isComplexSupportCall,
     isCustomerHarassmentCall,
+    isEmergencyCall,
     resolveHandoffDestination,
     shouldAutoHandoffGeneral,
     shouldAllowHumanHandoff,
@@ -135,6 +137,64 @@ test('handoff policy keeps non-urgent event calls in the call center', () => {
     assert.equal(isContractRequest(contractTurns), true);
     assert.equal(shouldAllowHumanHandoff(eventTurns, 'general'), false);
     assert.equal(shouldAllowHumanHandoff(contractTurns, 'contract'), true);
+});
+
+test('handoff classification keeps ordinary and non-urgent business inquiries out of human transfer', () => {
+    assert.equal(isSalesBusinessCall([{ role: 'user', text: '営業時間を教えてください。' }]), false);
+    assert.equal(isNonHandoffBusinessCall([{ role: 'user', text: '営業時間を教えてください。' }]), false);
+
+    for (const text of [
+        'エンジニアとして応募したいです。',
+        '業務提携について相談したいです。',
+        '御社の代理店になりたいです。',
+        '取材のお願いでお電話しました。'
+    ]) {
+        const turns = [{ role: 'user', text }];
+        assert.equal(isNonHandoffBusinessCall(turns), true, text);
+        assert.equal(isContractRequest(turns), false, text);
+        assert.equal(shouldAllowHumanHandoff(turns, 'general'), false, text);
+    }
+});
+
+test('handoff classification keeps urgent sales and partnership wording out of human transfer', () => {
+    for (const text of [
+        '急ぎの営業提案で代表の方におつなぎください。',
+        '至急、業務提携のご相談で担当者にお話ししたいです。',
+        '今日中に取材の件で責任者に確認したいです。'
+    ]) {
+        const turns = [{ role: 'user', text }];
+        assert.equal(shouldAutoHandoffGeneral(turns), true, text);
+        assert.equal(isNonHandoffBusinessCall(turns), true, text);
+        assert.equal(shouldAllowHumanHandoff(turns, 'general'), false, text);
+    }
+
+    const urgentRepresentativeTurns = [{ role: 'user', text: '急ぎで代表の方に相談したいです。' }];
+    assert.equal(isNonHandoffBusinessCall(urgentRepresentativeTurns), false);
+    assert.equal(shouldAllowHumanHandoff(urgentRepresentativeTurns, 'general'), true);
+});
+
+test('handoff classification escalates legal and security-risk consultations', () => {
+    for (const text of [
+        '契約を解除したいです。',
+        '個人情報が漏れたかもしれません。',
+        '不正アクセスされました。',
+        'セキュリティ事故が起きました。',
+        '法務か弁護士に相談したいです。'
+    ]) {
+        const turns = [{ role: 'user', text }];
+        assert.equal(isComplexSupportCall(turns), true, text);
+        assert.equal(isComplaintCall(turns), true, text);
+        assert.equal(isNonHandoffBusinessCall(turns), false, text);
+        assert.equal(resolveHandoffDestination(turns, 'contract'), 'general', text);
+    }
+});
+
+test('handoff classification keeps life-safety emergencies out of company transfer', () => {
+    const turns = [{ role: 'user', text: '人が倒れて意識がありません。救急車を呼んでください。' }];
+
+    assert.equal(isEmergencyCall(turns), true);
+    assert.equal(shouldAutoHandoffGeneral(turns), false);
+    assert.equal(shouldAllowHumanHandoff(turns, 'general'), false);
 });
 
 test('handoff whisper summary is one compact sentence', () => {

--- a/test/realtime-escalation.test.js
+++ b/test/realtime-escalation.test.js
@@ -31,6 +31,19 @@ test('payment disputes and complaints escalate to realtime 2.1 with human judgme
     assert.match(buildComplexRealtimeInstructions(result.category), /苦情や支払いトラブルだけを理由に担当者へ転送してはいけません/);
 });
 
+test('legal and security-risk consultations escalate to realtime 2.1', () => {
+    for (const text of [
+        '契約を解除したいです。',
+        '個人情報が漏れたかもしれません。',
+        '法務か弁護士に相談したいです。'
+    ]) {
+        const result = classifyRealtimeConversation([{ role: 'user', text }]);
+        assert.equal(result.targetModel, COMPLEX_REALTIME_MODEL, text);
+        assert.equal(result.category, 'complex_support', text);
+        assert.equal(result.humanTransferAllowed, true, text);
+    }
+});
+
 test('harassment escalates for careful AI handling but never permits human transfer', () => {
     const result = classifyRealtimeConversation([{
         role: 'user',

--- a/test/realtime-tool-flow.test.js
+++ b/test/realtime-tool-flow.test.js
@@ -235,6 +235,59 @@ test('Realtime tool flow blocks complaint transfer until complex model approval'
     assert.equal(output.reason, 'non_urgent_general_handoff');
 });
 
+test('Realtime tool flow permits legal transfer after complex-support escalation', () => {
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('transfer_to_human', 'handoff_legal_1', {
+            reason: '契約解除の法務相談',
+            destination: 'general'
+        }),
+        state: {
+            turns: [{ role: 'user', text: '契約を解除したいので法務に相談したいです。' }]
+        },
+        callEndConfig: buildCallEndConfig(),
+        handoffConfig: {
+            enabled: true,
+            numbers: ['+817085611659'],
+            destinationNumbers: { contract: '', general: '+817085611659' },
+            enforceRoutingPolicy: true
+        },
+        allowComplexComplaintHandoff: true
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.deepEqual(result.handoffRequests, [{
+        callId: 'handoff_legal_1',
+        reason: '契約解除の法務相談',
+        destination: 'general'
+    }]);
+    assert.equal(output.status, 'starting');
+});
+
+test('Realtime tool flow directs life-safety emergencies to emergency services', () => {
+    const result = handleRealtimeToolCalls({
+        event: toolEvent('transfer_to_human', 'handoff_emergency_1', {
+            reason: '救急車が必要',
+            destination: 'general'
+        }),
+        state: {
+            turns: [{ role: 'user', text: '人が倒れて意識がありません。' }]
+        },
+        callEndConfig: buildCallEndConfig(),
+        handoffConfig: {
+            enabled: true,
+            numbers: ['+817085611659'],
+            destinationNumbers: { contract: '', general: '+817085611659' },
+            enforceRoutingPolicy: true
+        },
+        allowComplexComplaintHandoff: true
+    });
+    const output = JSON.parse(result.outputs[0].item.output);
+
+    assert.deepEqual(result.handoffRequests, []);
+    assert.equal(output.reason, 'emergency_services');
+    assert.match(output.instruction, /110または119/);
+});
+
 test('Realtime tool flow keeps harassment in AI handling even after complex escalation', () => {
     const result = handleRealtimeToolCalls({
         event: toolEvent('transfer_to_human', 'handoff_harassment_blocked', {


### PR DESCRIPTION
## Summary
- Expand non-contract routing boundaries for recruiting applicants, partnerships, agencies, media, sponsorships, events, and ordinary inquiries.
- Keep urgent wording in sales/partnership/media calls from triggering human transfer, while preserving urgent representative support.
- Escalate legal, contract-dispute, privacy, and security-risk consultations to `gpt-realtime-2.1` and allow human transfer only after the complex model decides.
- Block life-safety emergencies from company transfer and guide callers to 110/119.
- Require callback contact and callback completion for complex complaint/support cases that are not transferred.

## Root cause
The previous policy treated any urgent keyword as eligible for general transfer, and the complex-support escalation category was not included in the post-escalation transfer allow-list. High-risk security phrases also had incomplete matching.

## Checks
- `npm test` (82 passed)
- classification matrix for contract, sales, applicant, partnership, media, event, hours, disability employment, payment, legal, privacy/security, emergency, and urgent representative cases
- `npm run check:realtime` reaches `gpt-realtime-2.1-mini`; the local key for the second model is invalid, so the 2.1 check remains a local credential blocker

## UAT
After merge/deploy, run live calls for urgent representative support, non-urgent sales/partnership/media/event, payment dispute, legal/security consultation, emergency-service wording, and callback completion. No secrets are included.