### PR TITLE
Pin Cloud Run runtime service account

### DIFF
--- a/.github/workflows/deploy-cloud-run.yml
+++ b/.github/workflows/deploy-cloud-run.yml
@@ -15,6 +15,7 @@ env:
   REGION: ${{ vars.CLOUD_RUN_REGION || 'asia-northeast1' }}
   SERVICE: ${{ vars.CLOUD_RUN_SERVICE || 'speech-assistant-realtime' }}
   DEPLOYER_SERVICE_ACCOUNT: ${{ vars.GCP_DEPLOYER_SERVICE_ACCOUNT }}
+  RUNTIME_SERVICE_ACCOUNT: ${{ vars.GCP_RUNTIME_SERVICE_ACCOUNT || 'speech-assistant-runtime@cor-jp-web.iam.gserviceaccount.com' }}
   WORKLOAD_IDENTITY_PROVIDER: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
   TWILIO_WEBHOOK_URL: ${{ vars.TWILIO_WEBHOOK_URL }}
   CALL_LOG_FIRESTORE_DATABASE_ID: ${{ vars.CALL_LOG_FIRESTORE_DATABASE_ID }}
@@ -85,6 +86,7 @@ jobs:
             --region "$REGION" \
             --source . \
             --allow-unauthenticated \
+            --service-account "$RUNTIME_SERVICE_ACCOUNT" \
             --min-instances 1 \
             --max-instances 5 \
             --concurrency 20 \


### PR DESCRIPTION
## Summary
- Explicitly deploy Cloud Run with `speech-assistant-runtime@cor-jp-web.iam.gserviceaccount.com`.
- Keep the build/deploy service account separate from the runtime identity.
- Add the runtime service account variable to the deploy workflow.

## Root cause
The migrated deploy workflow reached the source-build stage, but Cloud Run attempted to act as the project default Compute service account and the deployer lacked permission to use it. Omitting `--service-account` also risked changing runtime permissions on future revisions.

## Operational changes
- Granted the deployer permission to use the default Compute service account as the Cloud Build service identity.
- Workflow now pins the existing runtime service account explicitly.

## Validation
- Previous deploy reached source upload successfully before this runtime-identity fix.
- Local tests and live health/Media Stream smoke remain green from PR #84 deployment.